### PR TITLE
Adding connection timeout

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -69,6 +69,7 @@
                 queue,      % queue of pending requests
                 connects=0, % number of successful connects
                 failed=[],  % breakdown of failed connects
+                connect_timeout=infinity, % timeout of TCP connection
                 reconnect_interval=?FIRST_RECONNECT_INTERVAL}).
 -record(request, {ref :: reference(), msg :: rpb_req(), from, ctx :: ctx(), timeout :: integer(),
                   tref :: reference() | undefined }).
@@ -641,6 +642,8 @@ parse_options([], State) ->
         _ ->
             State
     end;
+parse_options([{connect_timeout, T}|Options], State) when is_integer(T) ->
+    parse_options(Options, State#state{connect_timeout = T});
 parse_options([{queue_if_disconnected,Bool}|Options], State) when 
       Bool =:= true; Bool =:= false ->
     parse_options(Options, State#state{queue_if_disconnected = Bool});
@@ -894,12 +897,13 @@ restart_req_timer(Request) ->
 connect(State) when State#state.sock =:= undefined ->
     #state{address = Address, port = Port, connects = Connects} = State,
     case gen_tcp:connect(Address, Port,
-                         [binary, {active, once}, {packet, 4}, {header, 1}]) of
+                         [binary, {active, once}, {packet, 4}, {header, 1}],
+                         State#state.connect_timeout) of
         {ok, Sock} ->
             {ok, State#state{sock = Sock, connects = Connects+1, 
                              reconnect_interval = ?FIRST_RECONNECT_INTERVAL}};
-        Error ->
-            Error
+        {error, Error} ->
+            {error, {tcp, Error}}
     end.
 
 %% @private


### PR DESCRIPTION
Currently, gen_tcp:connect/3 in connect/1 doesn't use any timeouts, so initiating a new PB socket connection may block us.
Also, we may want to try connecting another node that is probably reachable.

Finally, I added a small improvement of error handling here, to simplify the error messages. If it is a TCP error, it might be useful to separate such errors from any other.
