### PR TITLE
Fix ip_address() type for R14B03

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -61,7 +61,7 @@
 -define(FIRST_RECONNECT_INTERVAL, 100).
 -define(MAX_RECONNECT_INTERVAL, 30000).
 
--type address() :: string() | atom() | ip_address().
+-type address() :: string() | atom() | inet:ip_address().
 -type portnum() :: non_neg_integer().
 -type option()  :: queue_if_disconnected | {queue_if_disconnected, boolean()} |
                    auto_reconnect | {auto_reconnect, boolean()}.


### PR DESCRIPTION
This change is required for R14B03 (preview of latest erlang/otp dev branch).
