### PR TITLE
Allow local reuse of port numbers

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1136,8 +1136,8 @@ restart_req_timer(Request) ->
 connect(State) when State#state.sock =:= undefined ->
     #state{address = Address, port = Port, connects = Connects} = State,
     case gen_tcp:connect(Address, Port,
-                         [binary, {active, once}, {packet, 4}, {header, 1}],
-                         State#state.connect_timeout) of
+                         [binary, {active, once}, {packet, 4}, {header, 1},
+                          {reuseaddr, true}], State#state.connect_timeout) of
         {ok, Sock} ->
             {ok, State#state{sock = Sock, connects = Connects+1, 
                              reconnect_interval = ?FIRST_RECONNECT_INTERVAL}};


### PR DESCRIPTION
When making a lot of outgoing connections to Riak the local ports on the client machine can get saturated resulting in {error, eaddrinuse} on calls to the riakc_pb_socket:start_link/\* functions. Setting the {reuseaddr, true} option in the call to gen_tcp:connect/4 call in connect/1 eliminates this problem by allowing local port reuse.
