### PR TITLE
Allow local reuse of port numbers

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1136,8 +1136,8 @@ restart_req_timer(Request) ->
 connect(State) when State#state.sock =:= undefined ->
     #state{address = Address, port = Port, connects = Connects} = State,
     case gen_tcp:connect(Address, Port,
-                         [binary, {active, once}, {packet, 4}, {header, 1}],
-                         State#state.connect_timeout) of
+                         [binary, {active, once}, {packet, 4}, {header, 1},
+                          {reuseaddr, true}], State#state.connect_timeout) of
         {ok, Sock} ->
             {ok, State#state{sock = Sock, connects = Connects+1, 
                              reconnect_interval = ?FIRST_RECONNECT_INTERVAL}};


### PR DESCRIPTION
If the client has a lot of outgoing connections to Riak the client can get {error,eaddrinuse} on riakc_pb_socket:start_link/*. Setting the option {reuseaddr, true} in the gen_tcp:connect/4 call allows local port reuse avoid the connection problem.
