### PR TITLE
Fix typo in README file. There is no get/3 function that takes options

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ At some point you'll want that data back. Using the same bucket and key you used
     {{[],[],[],[],[],[],[],[],[],[],[],...}}},
     undefined}}
 
-Like `put/3`, there is a `get/3` function that takes options.
+Like `put/3`, there is a `get/4` function that takes options.
 
 <table border="1">
     <th>Option</th>


### PR DESCRIPTION
Function that README references is probably
riakc_pb_socket:get(Pid, Bucket, Key, Options)
and it takes 4 arguments. Function get/3 does not take Options
riakc_pb_socket:get(Pid, Bucket, Key)
