### PR TITLE
Fixed default_timeout

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -750,8 +750,8 @@ get_index(Pid, Bucket, Index, StartKey, EndKey, Timeout, CallTimeout) ->
 %%      Falls back to the default timeout.
 default_timeout(OpTimeout) ->
     case application:get_env(riakc, OpTimeout) of
-        {ok, OpTimeout} ->
-            OpTimeout;
+        {ok, EnvTimeout} ->
+            EnvTimeout;
         undefined ->
             case application:get_env(riakc, timeout) of
                 {ok, Timeout} ->


### PR DESCRIPTION
Was running a test using mapred_bucket_stream, manually setting mapred_bucket_stream_call_timeout, rather than using the default timeout, and it was failing.

After looking at the code, within the default_timeout function, I realized that the atom 'mapred_bucket_stream_call_timeout' was being passed in as a parameter and associated with variable OpTimeout - the same variable name was used to store the value returned from the application:get_env function.

The function was therefore returning the atom, and not the numbered value returned from application:get_env.

I've changed the name of the variable for the value returned from application:get_env, and returned this instead.
