### PR TITLE
Updates to spec's in riakc.hrl

### DIFF
--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -103,7 +103,7 @@
 %% function, that when evaluated points to a built-in javascript function.
 -type mapred_result() :: [term()].
 %% The results of a MapReduce job.
--type mapred_inputs() :: [{bucket(), key()} | {bucket(), key(), term()}] |
+-type mapred_inputs() :: [{bucket(), key()} | {{bucket(), key()}, term()}] |
                          {modfun, Module::atom(), Function::atom(), [term()]} |
                          bucket() |
                          {index, bucket(), Index::binary(), key()} |


### PR DESCRIPTION
I believe the current specs might be partially wrong:
- does not account for javascript map reduce queries
- complex inputs differ from documentation and usage

The specs for mapred_input's and mapred_funterm's partly deviate from actual usage (in the tests), and the specs described in the online documentation (although the docs refer to the http client: http://docs.basho.com/riak/latest/references/appendices/MapReduce-Implementation/).

@randysecrist confirmed on IRC that the pb client should be able to use javascript map reduce phases.
Unfortunately these were not allowed in the spec, causing dialyzer to fail on applications using javascript queries.

Likewise, the ability to provide inputs as {{bucket, key}, aux_data} was speced as {bucket, key, aux_data}, but used and documented differently.

These two commits change the specs to be inline with the documentation.
I have also amended the inline documentation.

Thanks for your time!
