### PR TITLE
get_metadata/1 no longer throws no_metadata exception

### DIFF
--- a/src/riakc_obj.erl
+++ b/src/riakc_obj.erl
@@ -292,6 +292,7 @@ contents0_test() ->
     ?assertEqual([], get_metadatas(O)),
     ?assertEqual([], get_values(O)),
     ?assertEqual([], get_contents(O)),
+    ?assertEqual(dict:new(), get_metadata(O)),
     ?assertThrow(no_value, get_value(O)).
 
 contents1_test() ->


### PR DESCRIPTION
Hi,

I had a look at issue https://github.com/basho/riak-erlang-client/issues/46. Updated the client to create an empty dict rather than throwing the `no_metadata` exception. This should be backwards compatible.

Best Regards,

Christian
