### PR TITLE
Correct some cases of badmatch with gen_tcp

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1642,7 +1642,7 @@ reset_ring() ->
 %% Finds the pid of the PB listener process
 riak_pb_listener_pid() ->
     {Children, Proc} = case riak_version() of
-                           [1,Two|_] when Two == 2->
+                           [1,Two|_] when Two >= 2->
                                {supervisor:which_children({riak_api_sup, test_riak_node()}),
                                 riak_api_pb_listener};
                            _ ->


### PR DESCRIPTION
In the new `loaded_upgrade` test from basho/riak_test#196, when Riak drops the connection or the socket is otherwise closed, we get an `{error, closed}` tuple returned from `gen_tcp:send/2` which results in a `badmatch` error.  This patch changes it to pattern match on the result and takes appropriate action to trigger a reconnect or enqueue, and when appropriate returns an `{error, disconnected}` tuple to the caller.
