### PR TITLE
update the client_option() type to fix riakcs dialyzer error

### DIFF
--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -26,9 +26,11 @@
 -define(FIRST_RECONNECT_INTERVAL, 100).
 -define(MAX_RECONNECT_INTERVAL, 30000).
 
--type client_option()  :: queue_if_disconnected | {queue_if_disconnected, boolean()} |
-                   {connect_timeout, integer()} |
-                   auto_reconnect | {auto_reconnect, boolean()}.
+-type client_option()  :: queue_if_disconnected | 
+                          {queue_if_disconnected, boolean()} |
+                          {connect_timeout, pos_integer()} | 
+                          auto_reconnect | 
+                          {auto_reconnect, boolean()}.
 %% Options for starting or modifying the connection:
 %% `queue_if_disconnected' when present or true will cause requests to
 %% be queued while the connection is down. `auto_reconnect' when


### PR DESCRIPTION
The type in riakc.hrl didn't have connect_timeout, causing dialyzer errors in riak cs.
