### PR TITLE
riakc_obj:new() Will Now Check for Invalid Empty Keys

### DIFF
--- a/src/riakc_obj.erl
+++ b/src/riakc_obj.erl
@@ -599,13 +599,7 @@ invalid_key_test() ->
     ?assertMatch({error, _}, riakc_obj:new(<<>>, <<>>)),
     ?assertMatch({error, _}, riakc_obj:new(<<>>, <<>>, <<"v">>)),
     ?assertMatch({error, _}, riakc_obj:new(<<>>, <<>>, <<"v">>, <<"application/x-foo">>)),
-
-    try riakc_obj:new("bucket","key") of
-        _-> ?assert(false)
-    catch
-        error:Error ->
-            ?assertEqual(Error, function_clause)
-    end.
+    ?assertError(function_clause, riakc_obj:new("bucket","key")).
 
 vclock_test() ->
     %% For internal use only


### PR DESCRIPTION
If a key equals <<"">> then an {error, msg} tuple will be returned instead of an #object record.

This is to closes #94: Protocol Buffers interface allows the creation of records with an empty key
