### PR TITLE
Issue #97: Allow new objects with 'undefined' key

### DIFF
--- a/src/riakc_obj.erl
+++ b/src/riakc_obj.erl
@@ -599,6 +599,7 @@ invalid_key_test() ->
     ?assertMatch({error, _}, riakc_obj:new(<<>>, <<>>)),
     ?assertMatch({error, _}, riakc_obj:new(<<>>, <<>>, <<"v">>)),
     ?assertMatch({error, _}, riakc_obj:new(<<>>, <<>>, <<"v">>, <<"application/x-foo">>)),
+    ?assertMatch(#riakc_obj{}, riakc_obj:new(<<"b">>, undefined)),
     ?assertError(function_clause, riakc_obj:new("bucket","key")).
 
 vclock_test() ->


### PR DESCRIPTION
Fix issue where undefined keys would work as described in the documentation [1]

This is related to issue #94 and #97

``` erlang
olav@nyx ~/s/riak-erlang-client> erl -pa ebin
Erlang R15B03 (erts-5.9.3) [source] [64-bit] [smp:4:4] [async-threads:0] [hipe] [kernel-poll:false]

Eshell V5.9.3  (abort with ^G)
1> riakc_obj:new(<<"b">>, undefined).
** exception error: no function clause matching riakc_obj:build_client_object(<<"b">>,undefined,undefined) (src/riakc_obj.erl, line 141)
```

[1] http://docs.basho.com/riak/latest/tutorials/querying/Basic-Operations/#Store-a-new-object-and-assign-random-key
