### PR TITLE
Fix dialyzer warnings

### DIFF
--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -137,7 +137,7 @@
                         timeout.
 
 -type secondary_index_id() :: {binary_index, string()} | {integer_index, string()}.
--type index_result() :: [key()].
+-type index_result() :: {keys, [key()]}.
 
 -type search_option() ::
         {rows, non_neg_integer()} |  %% Limit rows

--- a/src/riakc_obj.erl
+++ b/src/riakc_obj.erl
@@ -137,7 +137,8 @@ new(Bucket, Key, Value, ContentType) ->
     end.
 
 %% @doc Build a new riak client object with non-empty key
--spec build_client_object(bucket(), key(), value()) -> riakc_obj().
+-spec build_client_object(bucket(), key(), undefined | value()) ->
+                                 riakc_obj() | {error, atom()}.
 build_client_object(<<>>, K, _) when is_binary(K) ->
     {error, zero_length_bucket};
 build_client_object(B, <<>>, _) when is_binary(B) ->


### PR DESCRIPTION
Fix the following dialyzer warnings:

```
riakc_obj.erl:122: The call riakc_obj:build_client_object(Bucket::any(),Key::any(),'undefined') breaks the contract (bucket(),key(),value()) -> riakc_obj()
riakc_obj.erl:133: The pattern {'error', Reason} can never match the type #riakc_obj{bucket::binary(),key::'undefined' | binary(),contents::[],updatevalue::'undefined' | binary()}
```

Also, update the index_result spec type to reflect recent changes.
