### PR TITLE
Fix queue_disconnected_test

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -2028,7 +2028,6 @@ queue_disconnected_test() ->
     %% Start with an unlikely port number
     {ok, Pid} = start({127,0,0,1}, 65535, [queue_if_disconnected]),
     ?assertEqual({error, timeout}, ping(Pid, 10)),
-    ?assertEqual({error, timeout}, list_keys(Pid, <<"b">>, 10)),
     stop(Pid).
 
 auto_reconnect_bad_connect_test() ->


### PR DESCRIPTION
When running list_keys there are two timeouts.  The PB server timeout
and the list keys timeout.  Since the time this test was written, the
PB server timeout for the `list_keys` call was changed to `infinity`
and instead the timeout is passed to the list keys operation.  Thus
this test will timeout waiting indefinitely for the `list_keys` call
to return.  I've simply removed this assertion as it requires a
different context to be tested.
