### PR TITLE
Fix live_node_tests

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -2317,7 +2317,7 @@ riak_pb_listener_pid() ->
                                {supervisor:which_children({riak_api_sup, test_riak_node()}),
                                 riak_api_pb_listener}
                         end,
-    hd([Pid || {Mod,Pid,_,_} <- Children, Mod == Proc]).
+    hd([Pid || {_,Pid,_,[Mod]} <- Children, Mod == Proc]).
 
 pause_riak_pb_listener() ->
     Pid = riak_pb_listener_pid(),


### PR DESCRIPTION
There were a bunch of minor bugs in the live_node_tests. With these changes, all but one test passes, and that test exercises a known bug in Riak KV 2.0pre2. The error should look like:

```
  riakc_pb_socket:3228: live_node_tests (counter increment / decrement / get value)...*failed*
in function riakc_pb_socket:'-live_node_tests/0-fun-139-'/0 (src/riakc_pb_socket.erl, line 3236)
**error:{badmatch,{error,<<"Error processing incoming message: error:undef:[{riak_kv_cou"...>>}}
```
