### PR TITLE
Fix stream buckets with timeout

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -425,7 +425,7 @@ list_buckets(Pid, Type, Options) when is_binary(Type), is_list(Options) ->
 stream_list_buckets(Pid) ->
     stream_list_buckets(Pid, <<"default">>, []).
 
-stream_list_buckets(Pid, Type) when is_integer(Type) ->
+stream_list_buckets(Pid, Type) when is_binary(Type) ->
     stream_list_buckets(Pid, Type, []);
 stream_list_buckets(Pid, Timeout) when is_integer(Timeout) ->
     stream_list_buckets(Pid, <<"default">>,[{timeout, Timeout}]);


### PR DESCRIPTION
The wrong guard was used for bucket types, causing a call with a timeout
to fail. This fixes a problem found running the verify_api_timeouts riak
test
