### PR TITLE
Add 2i sort option

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info]}.
 {deps, [
-        {riak_pb, "2.0.0.7", {git, "git://github.com/basho/riak_pb", {tag, "2.0.0.7"}}}
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb", {branch, "feature/2i-sort-optional"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -107,6 +107,7 @@
                      {call_timeout, timeout()} |
                      {stream, boolean()} |
                      {continuation, binary()} |
+                     {sort, boolean()} |
                      {max_results, non_neg_integer() | all}.
 -type index_opts() :: [index_opt()].
 -type range_index_opt() :: {return_terms, boolean()}.
@@ -987,6 +988,7 @@ get_index_eq(Pid, Bucket, Index, Key, Opts) ->
     Timeout = proplists:get_value(timeout, Opts),
     CallTimeout = proplists:get_value(call_timeout, Opts, default_timeout(get_index_call_timeout)),
     MaxResults = proplists:get_value(max_results, Opts),
+    Sort = proplists:get_value(sort, Opts),
     Stream = proplists:get_value(stream, Opts, false),
     Continuation = proplists:get_value(continuation, Opts),
 
@@ -995,6 +997,7 @@ get_index_eq(Pid, Bucket, Index, Key, Opts) ->
     Req = #rpbindexreq{type=T, bucket=B, index=Index, qtype=eq,
                        key=encode_2i(Key),
                        max_results=MaxResults,
+                       sort=Sort,
                        stream=Stream,
                        continuation=Continuation,
                        timeout=Timeout},
@@ -1036,6 +1039,7 @@ get_index_range(Pid, Bucket, Index, StartKey, EndKey, Opts) ->
     CallTimeout = proplists:get_value(call_timeout, Opts, default_timeout(get_index_call_timeout)),
     ReturnTerms = proplists:get_value(return_terms, Opts),
     MaxResults = proplists:get_value(max_results, Opts),
+    Sort = proplists:get_value(sort, Opts),
     Stream = proplists:get_value(stream, Opts, false),
     Continuation = proplists:get_value(continuation, Opts),
 
@@ -1046,6 +1050,7 @@ get_index_range(Pid, Bucket, Index, StartKey, EndKey, Opts) ->
                        range_max=encode_2i(EndKey),
                        return_terms=ReturnTerms,
                        max_results=MaxResults,
+                       sort = Sort,
                        stream=Stream,
                        continuation=Continuation,
                        timeout=Timeout},


### PR DESCRIPTION
This is part of the fix for https://github.com/basho/riak_kv/pull/671
