### PR TITLE
Updates the test target in the Makefile to depend on all 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean:
 distclean: clean 
 	./rebar delete-deps
 
-test: 
+test: all
 	./rebar skip_deps=true eunit
 
 APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \


### PR DESCRIPTION
Updates the test target in the Makefile to depend on the <code>all</code> target (<code>deps</code> and <code>compile</code>). You need dependencies in place and source code compiled for tests to run.
