### PR TITLE
Changes to allow edoc to run succesfully.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,6 @@ build_plt: compile
 dialyzer: compile
 	@dialyzer --plt $(COMBO_PLT) -Wno_return -c ebin
 
-doc :
+doc : all
 	@./rebar doc skip_deps=true
 

--- a/rebar.config
+++ b/rebar.config
@@ -6,3 +6,4 @@
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.
+{clean_files, ["doc/*.html", "doc/*.png", "doc/edoc-info", "doc/*.css"]}.

--- a/src/riakc_datatype.erl
+++ b/src/riakc_datatype.erl
@@ -47,38 +47,38 @@
 -type context() :: maybe(binary()).
 -type update(T) :: maybe({typename(), T, context()}).
 
-%% @doc Constructs a new, empty container for the type. Use this when
+%% Constructs a new, empty container for the type. Use this when
 %% creating a new key.
 -callback new() -> datatype().
 
-%% @doc Constructs a new container for the type with the specified
+%% Constructs a new container for the type with the specified
 %% value and opaque server-side context. This should only be used
 %% internally by the client code.
 -callback new(Value::term(), context()) -> datatype().
 
-%% @doc Returns the original, unmodified value of the type. This does
+%% Returns the original, unmodified value of the type. This does
 %% not include the application of any locally-queued operations.
 -callback value(datatype()) -> term().
 
-%% @doc Returns a version of the value with locally-queued operations
+%% Returns a version of the value with locally-queued operations
 %% applied.
 -callback dirty_value(datatype()) -> term().
 
-%% @doc Extracts an operation from the container that can be encoded
+%% Extracts an operation from the container that can be encoded
 %% into an update request. 'undefined' should be returned if the type
 %% is unmodified. This should be passed to
 %% riakc_pb_socket:update_type() to submit modifications.
 -callback to_op(datatype()) -> update(term()).
 
-%% @doc Determines whether the given term is the type managed by the
+%% Determines whether the given term is the type managed by the
 %% container module.
 -callback is_type(datatype()) -> boolean().
 
-%% @doc Determines the symbolic name of the container's type, e.g.
+%% Determines the symbolic name of the container's type, e.g.
 %% set, map, counter.
 -callback type() -> typename().
 
-%% @doc Returns the module that is a container for the given abstract
+%% Returns the module that is a container for the given abstract
 %% type.
 -spec module(Type::atom()) -> module().
 module(set)      -> riakc_set;

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -33,7 +33,6 @@
 -include_lib("riak_pb/include/riak_search_pb.hrl").
 -include_lib("riak_pb/include/riak_yokozuna_pb.hrl").
 -include_lib("riak_pb/include/riak_dt_pb.hrl").
-%% @headerfile "riakc.hrl"
 -include("riakc.hrl").
 -behaviour(gen_server).
 
@@ -2588,12 +2587,11 @@ increase_reconnect_interval_test(State) ->
             increase_reconnect_interval_test(NextState)
     end.
 
-wait_until(Fun) when is_function(Fun) ->
-    wait_until(Fun, 20, 500).
-
-%% @doc Retry `Fun' until it returns `Retry' times, waiting `Delay'
+%% Retry `Fun' until it returns `Retry' times, waiting `Delay'
 %% milliseconds between retries. This is our eventual consistency bread
 %% and butter
+wait_until(Fun) when is_function(Fun) ->
+    wait_until(Fun, 20, 500).
 wait_until(_, 0, _) ->
     fail;
 wait_until(Fun, Retry, Delay) when Retry > 0 ->


### PR DESCRIPTION
Added edoc-generated files that need to be deleted during <code>clean</code> to <code>rebar.config</code>. The <code>doc</code> target in the <code>Makefile</code> now depends on <code>all</code>, which includes getting dependencies and compiling. Fixed edoc errors in <code>riakc_datatype.erl</code> and <code>riakc_pb_socket.erl</code>
