### PR TITLE
Fixed some Dialyzer issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,15 @@ distclean: clean
 test: 
 	./rebar skip_deps=true eunit
 
-APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
-	xmerl webtool snmp public_key mnesia eunit syntax_tools compiler
+APPS = kernel stdlib sasl erts eunit ssl tools crypto \
+       inets public_key syntax_tools compiler
 COMBO_PLT = $(HOME)/.riak_combo_dialyzer_plt
 
-check_plt: compile
+check_plt: all
 	dialyzer --check_plt --plt $(COMBO_PLT) --apps $(APPS) \
 		deps/*/ebin
 
-build_plt: compile
+build_plt: all
 	dialyzer --build_plt --output_plt $(COMBO_PLT) --apps $(APPS) \
 		deps/*/ebin
 

--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -44,7 +44,7 @@
 -type req_id() :: non_neg_integer(). %% Request identifier for streaming requests.
 -type server_prop() :: {node, binary()} | {server_version, binary()}. %% Server properties, as returned by the `get_server_info/1' call.
 -type server_info() :: [server_prop()]. %% A response from the `get_server_info/1' call.
--type bucket_prop() :: {n_val, pos_integer()} | {allow_mult, boolean()}. %% Bucket property definitions.
+-type bucket_prop() :: {n_val, pos_integer()} | {allow_mult, boolean()} | {search_index, binary()}. %% Bucket property definitions.
 -type bucket_props() :: [bucket_prop()]. %% Bucket properties
 -type quorum() :: non_neg_integer() | one | all | quorum | default.  %% A quorum setting for get/put/delete requests.
 -type read_quorum() :: {r, ReadQuorum::quorum()} |

--- a/src/riakc_register.erl
+++ b/src/riakc_register.erl
@@ -90,7 +90,7 @@ is_type(T) ->
 type() -> register.
 
 %% @doc Sets the value of the register.
--spec set(register(), binary()) -> register().
+-spec set(binary(), register()) -> register().
 set(Value, #register{}=R) when is_binary(Value) ->
     R#register{new_value=Value}.
 


### PR DESCRIPTION
Removed some apps from the build_plt Makefile target to speed up Dialyzer PLT generation.

Change the PLT-related Makefile targets to depend on all. Dialyzer needs the dependencies in place to generate PLTs.

Added <code>{search_index, binary()}</code> to the <code>-spec</code> for <code>server_prop</code>. This property describes a Yokozuna index. This gets rid of the following Dialyzer warning:

<pre>
riakc_pb_socket.erl:919: The call riakc_pb_socket:set_bucket(Pid::any(),Bucket::any(),[{'search_index',_},...]) will never return since the success typing is (pid(),binary(),[{'allow_mult',boolean()} | {'n_val',pos_integer()}]) -> 'ok' | {'error',_} and the contract is (pid(),bucket(),bucket_props()) -> 'ok' | {'error',term()}
</pre>


Fixed a <code>--spec</code> with the parameters in the wrong order causing the following Dialyzer warning:

<pre>
riakc_register.erl:93: Invalid type specification for function riakc_register:set/2. The success typing is (binary(),riakc_register:register()) -> riakc_register:register()
</pre>
