### PR TITLE
Fixes Dialyzer issues.

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -136,7 +136,7 @@
                 auto_reconnect = false :: boolean(), % if true, automatically reconnects to server
                                         % if false, exits on connection failure/request timeout
                 queue_if_disconnected = false :: boolean(), % if true, add requests to queue if disconnected
-                sock :: port(),       % gen_tcp socket
+                sock :: port() | ssl:sslsocket(),       % gen_tcp socket
                 transport = gen_tcp :: 'gen_tcp' | 'ssl',
                 active :: #request{} | undefined,     % active request
                 queue :: queue() | undefined,      % queue of pending requests
@@ -1958,7 +1958,7 @@ connect(State) when State#state.sock =:= undefined ->
         Error ->
             Error
     end.
-
+-spec start_tls(#state{}) -> term().
 start_tls(State=#state{sock=Sock}) ->
     %% Send STARTTLS
     StartTLSCode = riak_pb_codec:msg_code(rpbstarttls),


### PR DESCRIPTION
Adds sslsocket() as possible value assigned to the sock field of the state record in riakc_pb_socket.erl. This fixes  the following Dialyzer warnings.

<pre>
riakc_pb_socket.erl:1984: Record construction #state{address::atom() | string() | {byte(),byte(),byte(),byte()} | {char(),char(),char(),char(),char(),char(),char(),char()},port::'undefined' | non_neg_integer(),auto_reconnect::boolean(),queue_if_disconnected::boolean(),sock::{'sslsocket',_,_},transport::'ssl',active::'undefined' | #request{ref::'undefined' | reference(),msg::atom() | tuple(),timeout::'infinity' | 'undefined' | non_neg_integer(),tref::'undefined' | reference()},queue::'undefined' | queue(),connects::pos_integer(),failed::[{_,integer()}],connect_timeout::'infinity' | non_neg_integer(),credentials::'undefined' | {string(),string()},reconnect_interval::100} violates the declared type of field sock::'undefined' | port()
riakc_pb_socket.erl:1999: Function start_auth/1 will never be called
</pre>
