### PR TITLE
Add option for enabling TCP keepalive

### DIFF
--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -1,3 +1,4 @@
+
 %% -------------------------------------------------------------------
 %%
 %% riakc: protocol buffer client
@@ -30,7 +31,9 @@
                           {queue_if_disconnected, boolean()} |
                           {connect_timeout, pos_integer()} |
                           auto_reconnect |
-                          {auto_reconnect, boolean()}.
+                          {auto_reconnect, boolean()} |
+                          keepalive |
+                          {keepalive, boolean()}.
 %% Options for starting or modifying the connection:
 %% `queue_if_disconnected' when present or true will cause requests to
 %% be queued while the connection is down. `auto_reconnect' when


### PR DESCRIPTION
It isn't clear if there is a reason for this not being an option already.

This comes up in situations when pooling connections.  What ends up happening is that the pool fills up with dead connections during periods of inactivity, and requests will end up failing until the bad connections are cleaned out due to failed requests.  Not really ideal.

While I've adjusted our pooler to reap connections somewhat during this period, I'm not convinced that it is up to the pooler to determine the liveness of the connection.

One open question is if it is worthwhile to implement an alternative option for clients without TCP keepalive support.  This could periodically send a 'ping' request to the node.  Not valuable for me personally, but is potentially a more controllable means of implementing this feature.
