### PR TITLE
Fix unhandled case of empty cs buckets response

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1423,6 +1423,8 @@ process_response(#request{msg = #rpbindexreq{return_terms=Terms}}, #rpbindexresp
     RegularResponse = index_stream_result_to_index_result(StreamResponse),
     RegularResponseWithContinuation = RegularResponse?INDEX_RESULTS{continuation=Cont},
     {reply, {ok, RegularResponseWithContinuation}, State};
+process_response(#request{msg = #rpbcsbucketreq{}}, rpbcsbucketresp, State) ->
+    {pending, State};
 process_response(#request{msg = #rpbcsbucketreq{bucket=Bucket}}=Request, #rpbcsbucketresp{objects=Objects, done=Done, continuation=Cont}, State) ->
     %% TEMP - cs specific message for fold_objects
     ToSend =  case Objects of


### PR DESCRIPTION
the PB translation generates a single token instead of a default record
when the entire message has only default values. This was uncovered in
1.4.4, where the cs buckets query was broken.
