### PR TITLE
Add 2i changes from 1.4.4-1.4.6

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info]}.
 {deps, [
-        {riak_pb, "2.0.0.10", {git, "git://github.com/basho/riak_pb", {tag, "2.0.0.10"}}}
+        {riak_pb, "2.0.0.11", {git, "git://github.com/basho/riak_pb", {tag, "2.0.0.11"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.


### PR DESCRIPTION
- Add 2i pagination sort option
- Add term regex option to 2i queries
- Fix unhandled case of empty cs buckets response
