### PR TITLE
Add n_val to Create and Read Indexes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info]}.
 {deps, [
-        {riak_pb, "2.0.0.12", {git, "git://github.com/basho/riak_pb", {tag, "2.0.0.12"}}}
+        {riak_pb, "2.0.0.13", {git, "git://github.com/basho/riak_pb", {tag, "2.0.0.13"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.


### PR DESCRIPTION
Yokozuna indexes new require an n_val to further decouple indexes from kv buckets.

basho/yokozuna#290
