### PR TITLE
'module' function definition conflict

### DIFF
--- a/src/riakc_datatype.erl
+++ b/src/riakc_datatype.erl
@@ -36,7 +36,7 @@
 
 -define(MODULES, [riakc_set, riakc_counter, riakc_flag, riakc_register, riakc_map]).
 
--export([module/1,
+-export([module_for_type/1,
          module_for_term/1]).
 
 -export_type([datatype/0, update/1, context/0]).
@@ -80,12 +80,12 @@
 
 %% Returns the module that is a container for the given abstract
 %% type.
--spec module(Type::atom()) -> module().
-module(set)      -> riakc_set;
-module(counter)  -> riakc_counter;
-module(flag)     -> riakc_flag;
-module(register) -> riakc_register;
-module(map)      -> riakc_map.
+-spec module_for_type(Type::atom()) -> module().
+module_for_type(set)      -> riakc_set;
+module_for_type(counter)  -> riakc_counter;
+module_for_type(flag)     -> riakc_flag;
+module_for_type(register) -> riakc_register;
+module_for_type(map)      -> riakc_map.
 
 %% @doc Returns the appropriate container module for the given term,
 %% if possible.
@@ -175,5 +175,5 @@ prop_module_for_term(Mod) ->
 prop_module_type() ->
     %% module/1 returns the correct wrapper module for the type.
     ?FORALL(Mod, elements(?MODULES),
-            module(Mod:type()) == Mod).
+            module_for_type(Mod:type()) == Mod).
 -endif.

--- a/src/riakc_map.erl
+++ b/src/riakc_map.erl
@@ -255,7 +255,7 @@ find_or_new(Key, Values) ->
 %% @private
 -spec type_module(key()) -> module().
 type_module({_, T}) ->
-    riakc_datatype:module(T).
+    riakc_datatype:module_for_type(T).
 
 %% @doc Folder for extracting operations from embedded types.
 -spec fold_extract_op(key(), riakc_datatype:datatype(), [field_update()]) -> [field_update()].
@@ -310,14 +310,14 @@ gen_update_fun(Type) ->
                {1, gen_update_fun2(Type)}]).
 
 gen_update_fun1(Type) ->
-    Mod = riakc_datatype:module(Type),
+    Mod = riakc_datatype:module_for_type(Type),
     ?LET({Op, Args}, Mod:gen_op(),
          fun(R) ->
                  erlang:apply(Mod, Op, Args ++ [R])
          end).
 
 gen_update_fun2(Type) ->
-    Mod = riakc_datatype:module(Type),
+    Mod = riakc_datatype:module_for_type(Type),
     ?LET(OpList, non_empty(list(Mod:gen_op())),
          fun(R) ->
                  lists:foldl(fun({Op, Args}, Acc) ->

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1206,7 +1206,7 @@ modify_type(Pid, Fun, BucketAndType, Key, Options) ->
             update_type(Pid, BucketAndType, Key, Mod:to_op(NewData), Options);
         {error, {notfound, Type}} when Create ->
             %% Not found, but ok to create it
-            Mod = riakc_datatype:module(Type),
+            Mod = riakc_datatype:module_for_type(Type),
             NewData = Fun(Mod:new()),
             update_type(Pid, BucketAndType, Key, Mod:to_op(NewData), Options);
         {error, Reason} ->
@@ -1765,7 +1765,7 @@ process_response(#request{msg = #dtfetchreq{}}, #dtfetchresp{}=Resp,
                  State) ->
     Reply = case riak_pb_dt_codec:decode_fetch_response(Resp) of
                 {Type, Value, Context}  ->
-                    Mod = riakc_datatype:module(Type),
+                    Mod = riakc_datatype:module_for_type(Type),
                     {ok, Mod:new(Value, Context)};
                 {notfound, _Type}=NF ->
                     {error, NF}
@@ -1785,10 +1785,10 @@ process_response(#request{msg = #dtupdatereq{op=Op, return_body=RB}},
                 ok -> ok;
                 {ok, Key} -> {ok, Key};
                 {OpType, Value, Context} ->
-                    Mod = riakc_datatype:module(OpType),
+                    Mod = riakc_datatype:module_for_type(OpType),
                     {ok, Mod:new(Value, Context)};
                 {Key, {OpType, Value, Context}} when is_binary(Key) ->
-                    Mod = riakc_datatype:module(OpType),
+                    Mod = riakc_datatype:module_for_type(OpType),
                     {ok, Key, Mod:new(Value, Context)}
             end,
     {reply, Reply, State};


### PR DESCRIPTION
`riakc_data` defines a function called `module/1`. QuickCheck also exports a function called `module/1`, which gets imported (unqualified) with `-include_lib("eqc/include/eqc.hrl").` This produces either a warning or an error, depending on the version of Erlang:

R16B02:

```
QuickCheck warning: cannot import module/1 because of conflicting definition.
```

R15B01:

```
./rebar eunit skip_deps=true
==> riak-erlang-client (eunit)
src/riakc_datatype.erl:84: defining imported function module/1
ERROR: eunit failed while processing /Users/reid/Documents/repos/basho/riak-erlang-client: rebar_abort
```

cc/ @seancribbs 
