### PR TITLE
Never use infinity request timeouts

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -401,7 +401,7 @@ stream_list_buckets(Pid, Options) ->
     ReqId = mk_reqid(),
     gen_server:call(Pid, {req, #rpblistbucketsreq{timeout=ServerTimeout,
                                                   stream=true},
-                          infinity, {ReqId, self()}}, infinity).
+                          ServerTimeout, {ReqId, self()}}, infinity).
 
 legacy_list_buckets(Pid, Options) ->
     ServerTimeout =
@@ -410,7 +410,7 @@ legacy_list_buckets(Pid, Options) ->
             ST -> ST
         end,
     gen_server:call(Pid, {req, #rpblistbucketsreq{timeout=ServerTimeout},
-                          infinity}, infinity).
+                          ServerTimeout}, infinity).
 
 
 %% @doc List all keys in a bucket
@@ -466,7 +466,7 @@ stream_list_keys(Pid, Bucket, Options) ->
         end,
     ReqMsg = #rpblistkeysreq{bucket = Bucket, timeout = ServerTimeout},
     ReqId = mk_reqid(),
-    gen_server:call(Pid, {req, ReqMsg, infinity, {ReqId, self()}},
+    gen_server:call(Pid, {req, ReqMsg, ServerTimeout, {ReqId, self()}},
                     infinity).
 
 %% @doc Get bucket properties.
@@ -823,9 +823,9 @@ get_index_eq(Pid, Bucket, Index, Key, Opts) ->
     Call = case Stream of
                true ->
                    ReqId = mk_reqid(),
-                   {req, Req, infinity, {ReqId, self()}};
+                   {req, Req, Timeout, {ReqId, self()}};
                false ->
-                   {req, Req, infinity}
+                   {req, Req, Timeout}
            end,
     gen_server:call(Pid, Call, CallTimeout).
 
@@ -875,9 +875,9 @@ get_index_range(Pid, Bucket, Index, StartKey, EndKey, Opts) ->
     Call = case Stream of
                true ->
                    ReqId = mk_reqid(),
-                   {req, Req, infinity, {ReqId, self()}};
+                   {req, Req, Timeout, {ReqId, self()}};
                false ->
-                   {req, Req, infinity}
+                   {req, Req, Timeout}
            end,
     gen_server:call(Pid, Call, CallTimeout).
 
@@ -909,7 +909,7 @@ cs_bucket_fold(Pid, Bucket, Opts) when is_pid(Pid), is_binary(Bucket), is_list(O
                           continuation=Continuation,
                           timeout=Timeout},
     ReqId = mk_reqid(),
-    Call = {req, Req, infinity, {ReqId, self()}},
+    Call = {req, Req, Timeout, {ReqId, self()}},
     gen_server:call(Pid, Call, CallTimeout).
 
 %% @doc Return the default timeout for an operation if none is provided.


### PR DESCRIPTION
Backport of 5aa1ab0ba214d8ec5b595735cf3822c3a4e9c49d

As described in #156, there are several types of timeouts in the client.
The timeout that is generally provided as the last argument to client
operations is used to create timers which prevent us from waiting for
every on messages for TCP data (from gen_tcp). There are several cases
where this timeout was hardcoded to infinity. This can cause the client
to hang on these requests for a (mostly) unbounded time. Even when using
a gen_server timeout, the gen_server itself will continue to wait for
the message to come, with no timeout. Further, because of #155, we
simply use the `ServerTimeout` as the `RequestTimeout`, if there is not
a separate `RequestTimeout`. It's possible that the `RequestTimeout` can
fire before the `ServerTimeout` (this timeout is remote), but we'd
otherwise just be picking some random number to be the difference
between them. Addressing #155 will shed more light on this.
