### PR TITLE
riakc_map QC test occasionally fails

### DIFF
--- a/src/riakc_map.erl
+++ b/src/riakc_map.erl
@@ -263,7 +263,7 @@ fold_extract_op(Key, Value, Acc0) ->
     Mod = type_module(Key),
     case Mod:to_op(Value) of
         undefined ->
-            Acc0;
+            [{add, Key}|Acc0];
         {_Type, Op, _Context} ->
             [{update, Key, Op} | Acc0]
     end.


### PR DESCRIPTION
It seems to only fail maybe 1 in 20 times or so. Here's an example output when it does fail:

```
  riakc_datatype:114: datatypes_test_ ( prop_modified(riakc_map) ).................Failed! After 15 tests.
{{map,[{{<<"\t\\">>,set},[<<"O<C1>">>]}],[],[],[],<<>>},
 {update,[{<<"<B8><D5>">>,counter},#Fun<riakc_map.9.9328923>]}}
Shrinking...(3 times)
{{map,[],[],[],[],<<>>},{update,[{<<>>,counter},#Fun<riakc_map.9.9328923>]}}
*failed*
in function riakc_datatype:'-datatypes_test_/0-fun-4-'/3 (src/riakc_datatype.erl, line 114)
**error:{assertEqual_failed,[{module,riakc_datatype},
                     {line,114},
                     {expression,"quickcheck ( ? QC_OUT ( eqc : testing_time ( 2 , ? MODULE : Prop ( Mod ) ) ) )"},
                     {expected,true},
                     {value,false}]}

```

On master, 2e5d946ab57b63ffeb99986ac556607a09dfd35b.
