### PR TITLE
Set multiValued false in schema test

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -3436,7 +3436,6 @@ live_node_tests() ->
      {timeout, 30, ?_test(begin
                 reset_riak(),
                 {ok, Pid} = start_link(test_ip(), test_port()),
-                reset_solr(Pid),
                 Index = <<"myindex">>,
                 Bucket = <<"mybucket">>,
                 ?assertEqual(ok, ?MODULE:create_search_index(Pid, Index)),


### PR DESCRIPTION
With basho/yokozuna#393, multiValued must now be set to false in solr schemas. This changes those values in the test, as well as fixes `wait_until`s to be value based, rather than assuming a property list order.
