### PR TITLE
Add a RangeReg - a new top-level datatype

### DIFF
--- a/src/riakc_counter.erl
+++ b/src/riakc_counter.erl
@@ -31,7 +31,7 @@
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--compile(export_all).
+-export([gen_type/0, gen_op/0]).
 -endif.
 
 %% Callbacks

--- a/src/riakc_datatype.erl
+++ b/src/riakc_datatype.erl
@@ -35,7 +35,7 @@
 
 
 -define(MODULES, [riakc_set, riakc_counter, riakc_flag, riakc_register, riakc_map,
-                  riakc_rangereg]).
+                  riakc_range]).
 
 -export([module_for_type/1,
          module_for_term/1]).
@@ -96,7 +96,7 @@ module_for_type(counter)  -> riakc_counter;
 module_for_type(flag)     -> riakc_flag;
 module_for_type(register) -> riakc_register;
 module_for_type(map)      -> riakc_map;
-module_for_type(rangereg) -> riakc_rangereg.
+module_for_type(range)    -> riakc_range.
 
 %% @doc Returns the appropriate container module for the given term,
 %% if possible.

--- a/src/riakc_datatype.erl
+++ b/src/riakc_datatype.erl
@@ -34,7 +34,8 @@
 -endif.
 
 
--define(MODULES, [riakc_set, riakc_counter, riakc_flag, riakc_register, riakc_map]).
+-define(MODULES, [riakc_set, riakc_counter, riakc_flag, riakc_register, riakc_map,
+                  riakc_rangereg]).
 
 -export([module_for_type/1,
          module_for_term/1]).
@@ -94,7 +95,8 @@ module_for_type(set)      -> riakc_set;
 module_for_type(counter)  -> riakc_counter;
 module_for_type(flag)     -> riakc_flag;
 module_for_type(register) -> riakc_register;
-module_for_type(map)      -> riakc_map.
+module_for_type(map)      -> riakc_map;
+module_for_type(rangereg) -> riakc_rangereg.
 
 %% @doc Returns the appropriate container module for the given term,
 %% if possible.

--- a/src/riakc_datatype.erl
+++ b/src/riakc_datatype.erl
@@ -78,6 +78,15 @@
 %% set, map, counter.
 -callback type() -> typename().
 
+
+-ifdef(EQC).
+
+-callback gen_type() -> eqc_gen:gen(datatype()).
+
+-callback gen_op()   -> eqc_gen:gen({atom(), [term()]}).
+
+-endif.
+
 %% Returns the module that is a container for the given abstract
 %% type.
 -spec module_for_type(Type::atom()) -> module().

--- a/src/riakc_flag.erl
+++ b/src/riakc_flag.erl
@@ -33,7 +33,7 @@
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--compile(export_all).
+-export([gen_type/0, gen_op/0]).
 -endif.
 
 %% Callbacks

--- a/src/riakc_map.erl
+++ b/src/riakc_map.erl
@@ -90,6 +90,7 @@
                             riakc_set:set_op() |
                             riakc_flag:flag_op() |
                             riakc_register:register_op() |
+                            riakc_rangereg:rangereg_op() |
                             map_op().
 -type field_update() :: {update, key(), embedded_type_op()}.
 -type simple_map_op() :: {remove, key()} | field_update().
@@ -261,6 +262,7 @@ gen_entry(S) ->
                             {5, riakc_register},
                             {5, riakc_counter},
                             {5, riakc_set},
+                            {5, riakc_rangereg},
                             {1, riakc_map}
                            ],
               Fr >= 5 orelse S >= 5]).

--- a/src/riakc_map.erl
+++ b/src/riakc_map.erl
@@ -53,6 +53,7 @@
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-export([gen_type/0, gen_op/0]).
 -compile(export_all).
 -endif.
 

--- a/src/riakc_range.erl
+++ b/src/riakc_range.erl
@@ -35,7 +35,7 @@
          type/0]).
 
 -export([max/1, min/1, first/1, last/1,
-         assign/2]).
+         add/2]).
 
 -record(range, {
           value :: undefined | fieldlist(),
@@ -84,8 +84,8 @@ last(#range{value=undefined}) -> undefined;
 last(#range{value=Val}) ->
     proplists:get_value(last, Val).
 
--spec assign(integer(), range()) -> range().
-assign(NewVal, MR) ->
+-spec add(integer(), range()) -> range().
+add(NewVal, MR) ->
     MR#range{new_value=NewVal}.
 
 -spec to_op(range()) -> riakc_datatype:update(range_op()).
@@ -106,7 +106,7 @@ gen_type() ->
     ?LET(Value, int(), new([{max, Value}, {min, Value-10}, {first, Value-10}, {last, Value}], undefined)).
 
 gen_op() ->
-    {assign,
+    {add,
      ?LET(NewVal, int(), [NewVal])
     }.
 

--- a/src/riakc_range.erl
+++ b/src/riakc_range.erl
@@ -20,7 +20,7 @@
 %%
 %% -------------------------------------------------------------------
 
--module(riakc_rangereg).
+-module(riakc_range).
 -behaviour(riakc_datatype).
 
 -ifdef(EQC).
@@ -37,68 +37,68 @@
 -export([max/1, min/1, first/1, last/1,
          assign/2]).
 
--record(rangereg, {
+-record(range, {
           value :: undefined | fieldlist(),
           new_value = undefined :: undefined | integer()
          }).
 -type field() :: min | max | first | last.
 -type fieldlist() :: [{field(), integer()}].
 
--export_type([rangereg/0, rangereg_op/0]).
--opaque rangereg() :: #rangereg{}.
--type rangereg_op() :: {assign, integer()}.
+-export_type([range/0, range_op/0]).
+-opaque range() :: #range{}.
+-type range_op() :: {assign, integer()}.
 
--spec new() -> rangereg().
+-spec new() -> range().
 new() ->
-    #rangereg{}.
+    #range{}.
 
--spec new(riakc_datatype:context()) -> rangereg().
+-spec new(riakc_datatype:context()) -> range().
 new(_Ctx) ->
-    #rangereg{}.
+    #range{}.
 
--spec new(fieldlist(), riakc_datatype:context()) -> rangereg().
+-spec new(fieldlist(), riakc_datatype:context()) -> range().
 new(Value, _Ctx) ->
-    #rangereg{value=Value}.
+    #range{value=Value}.
 
--spec value(rangereg()) -> undefined | fieldlist().
-value(#rangereg{value=Val}) ->
+-spec value(range()) -> undefined | fieldlist().
+value(#range{value=Val}) ->
     Val.
 
--spec max(rangereg()) -> undefined | integer().
-max(#rangereg{value=undefined}) -> undefined;
-max(#rangereg{value=Val}) ->
+-spec max(range()) -> undefined | integer().
+max(#range{value=undefined}) -> undefined;
+max(#range{value=Val}) ->
     proplists:get_value(max, Val).
 
--spec min(rangereg()) -> undefined | integer().
-min(#rangereg{value=undefined}) -> undefined;
-min(#rangereg{value=Val}) ->
+-spec min(range()) -> undefined | integer().
+min(#range{value=undefined}) -> undefined;
+min(#range{value=Val}) ->
     proplists:get_value(min, Val).
 
--spec first(rangereg()) -> undefined | integer().
-first(#rangereg{value=undefined}) -> undefined;
-first(#rangereg{value=Val}) ->
+-spec first(range()) -> undefined | integer().
+first(#range{value=undefined}) -> undefined;
+first(#range{value=Val}) ->
     proplists:get_value(first, Val).
 
--spec last(rangereg()) -> undefined | integer().
-last(#rangereg{value=undefined}) -> undefined;
-last(#rangereg{value=Val}) ->
+-spec last(range()) -> undefined | integer().
+last(#range{value=undefined}) -> undefined;
+last(#range{value=Val}) ->
     proplists:get_value(last, Val).
 
--spec assign(integer(), rangereg()) -> rangereg().
+-spec assign(integer(), range()) -> range().
 assign(NewVal, MR) ->
-    MR#rangereg{new_value=NewVal}.
+    MR#range{new_value=NewVal}.
 
--spec to_op(rangereg()) -> riakc_datatype:update(rangereg_op()).
-to_op(#rangereg{new_value=undefined}) ->
+-spec to_op(range()) -> riakc_datatype:update(range_op()).
+to_op(#range{new_value=undefined}) ->
     undefined;
-to_op(#rangereg{new_value=NewVal}) ->
-    {type(), {assign, NewVal}, undefined}.
+to_op(#range{new_value=NewVal}) ->
+    {type(), {add, NewVal}, undefined}.
 
 -spec is_type(term()) -> boolean().
-is_type(T) -> is_record(T, rangereg).
+is_type(T) -> is_record(T, range).
 
 -spec type() -> atom().
-type() -> rangereg.
+type() -> range.
 
 -ifdef(EQC).
 

--- a/src/riakc_rangereg.erl
+++ b/src/riakc_rangereg.erl
@@ -1,0 +1,113 @@
+%% -------------------------------------------------------------------
+%%
+%% riakc_rangereg: 
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riakc_rangereg).
+-behaviour(riakc_datatype).
+
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-export([gen_type/0, gen_op/0]).
+-endif.
+
+-export([new/0, new/1, new/2,
+         value/1,
+         to_op/1,
+         is_type/1,
+         type/0]).
+
+-export([max/1, min/1, first/1, last/1,
+         assign/2]).
+
+-record(rangereg, {
+          value :: undefined | fieldlist(),
+          new_value = undefined :: undefined | integer()
+         }).
+-type field() :: min | max | first | last.
+-type fieldlist() :: [{field(), integer()}].
+
+-export_type([rangereg/0, rangereg_op/0]).
+-opaque rangereg() :: #rangereg{}.
+-type rangereg_op() :: {assign, integer()}.
+
+-spec new() -> rangereg().
+new() ->
+    #rangereg{}.
+
+-spec new(riakc_datatype:context()) -> rangereg().
+new(_Ctx) ->
+    #rangereg{}.
+
+-spec new(fieldlist(), riakc_datatype:context()) -> rangereg().
+new(Value, _Ctx) ->
+    #rangereg{value=Value}.
+
+-spec value(rangereg()) -> undefined | fieldlist().
+value(#rangereg{value=Val}) ->
+    Val.
+
+-spec max(rangereg()) -> undefined | integer().
+max(#rangereg{value=undefined}) -> undefined;
+max(#rangereg{value=Val}) ->
+    proplists:get_value(max, Val).
+
+-spec min(rangereg()) -> undefined | integer().
+min(#rangereg{value=undefined}) -> undefined;
+min(#rangereg{value=Val}) ->
+    proplists:get_value(min, Val).
+
+-spec first(rangereg()) -> undefined | integer().
+first(#rangereg{value=undefined}) -> undefined;
+first(#rangereg{value=Val}) ->
+    proplists:get_value(first, Val).
+
+-spec last(rangereg()) -> undefined | integer().
+last(#rangereg{value=undefined}) -> undefined;
+last(#rangereg{value=Val}) ->
+    proplists:get_value(last, Val).
+
+-spec assign(integer(), rangereg()) -> rangereg().
+assign(NewVal, MR) ->
+    MR#rangereg{new_value=NewVal}.
+
+-spec to_op(rangereg()) -> riakc_datatype:update(rangereg_op()).
+to_op(#rangereg{new_value=undefined}) ->
+    undefined;
+to_op(#rangereg{new_value=NewVal}) ->
+    {rangereg, {assign, NewVal}, undefined}.
+
+-spec is_type(term()) -> bool.
+is_type(T) -> is_record(T, rangereg).
+
+-spec type() -> atom().
+type() -> rangereg.
+
+-ifdef(EQC).
+
+gen_type() ->
+    ?LET(Value, int(), new([{max, Value}, {min, Value-10}, {first, Value-10}, {last, Value}], undefined)).
+
+gen_op() ->
+    {assign,
+     ?LET(NewVal, int(), [NewVal])
+    }.
+
+-endif.

--- a/src/riakc_rangereg.erl
+++ b/src/riakc_rangereg.erl
@@ -92,9 +92,9 @@ assign(NewVal, MR) ->
 to_op(#rangereg{new_value=undefined}) ->
     undefined;
 to_op(#rangereg{new_value=NewVal}) ->
-    {rangereg, {assign, NewVal}, undefined}.
+    {type(), {assign, NewVal}, undefined}.
 
--spec is_type(term()) -> bool.
+-spec is_type(term()) -> boolean().
 is_type(T) -> is_record(T, rangereg).
 
 -spec type() -> atom().

--- a/src/riakc_register.erl
+++ b/src/riakc_register.erl
@@ -33,7 +33,7 @@
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--compile(export_all).
+-export([gen_type/0, gen_op/0]).
 -endif.
 
 %% Callbacks

--- a/src/riakc_set.erl
+++ b/src/riakc_set.erl
@@ -49,7 +49,7 @@
 
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
--compile(export_all).
+-export([gen_type/0, gen_op/0]).
 -endif.
 
 %% Callbacks


### PR DESCRIPTION
Rangereg is a register for integers that tracks the largest,
the smallest, the first (by timestamp) and the last (by timestamp)
integers assigned into it.

This allows you to assign new integers to the rangereg 
(however, without specifying the timestamp).

This is part of the changes in basho/riak_kv#1005 .

There is also a commit that improves the callback interface in riakc_datatype.
