### PR TITLE
A PB list element is encoded as the empty list when absent, not undefined

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1593,7 +1593,7 @@ process_response(#request{msg = #rpbgetreq{}}, rpbgetresp, State) ->
     %% server just returned the rpbgetresp code - no message was encoded
     {reply, {error, notfound}, State};
 process_response(#request{msg = #rpbgetreq{deletedvclock=true}},
-                 #rpbgetresp{vclock=VC, content=undefined}, State) ->
+                 #rpbgetresp{vclock=VC, content=[]}, State) ->
     %% server returned a notfound with a vector clock, meaning a tombstone
     {reply, {error, notfound, VC}, State};
 process_response(#request{msg = #rpbgetreq{}}, #rpbgetresp{unchanged=true}, State) ->


### PR DESCRIPTION
When performing a `riakc_pb_socket:get(Key, Val, [deletedvclock])` in the case that a tombstone was returned by riak, the client returned `{ok, RiakcObj}` and not `{error, notfound, TombstoneVClock}` as expected. The fault comes from the function clause expecting the `content` field of `#rpbgetresp` to be `undefined` for a tombstone, when it is in fact the empty list.

To test, set up a cluster with `{delete_mode, keep}`, add a key, delete it, fetch the tombstone with  `riakc_pb_socket:get(Key, Val, [deletedvclock])`. Before the patch you well get an `{ok, Val}` return, after you will get `{error, notfound, VC}` where `VC` is the tombstone vlclock.
