### PR TITLE
Bugfix to strip 'create' option from riakc_pb_socket:modify_type/5

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1194,8 +1194,10 @@ update_type(Pid, BucketAndType, Key, {Type, Op, Context}, Options) ->
 -spec modify_type(pid(), fun((riakc_datatype:datatype()) -> riakc_datatype:datatype()),
                   {BucketType::binary(), Bucket::binary()}, Key::binary(), [proplists:property()]) ->
                          ok | {ok, riakc_datatype:datatype()} | {error, term()}.
-modify_type(Pid, Fun, BucketAndType, Key, Options) ->
-    Create = proplists:get_value(create, Options, true),
+modify_type(Pid, Fun, BucketAndType, Key, ModifyOptions) ->
+    Create = proplists:get_value(create, ModifyOptions, true),
+    Options = proplists:delete(create, ModifyOptions),
+
     case fetch_type(Pid, BucketAndType, Key, Options) of
         {ok, Data} ->
             NewData = Fun(Data),


### PR DESCRIPTION
Passing forward the 'create' option when it is an invalid option for Fetch or Update causes the 'dialyzer' to throw an error since it's not one of the members of riak_pb's fetch_opts() type.