### PR TITLE
add get_preflist to erlang-client

### DIFF
--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -69,7 +69,6 @@
                       {n_val, pos_integer()} |
                       {sloppy_quorum, boolean()}.
 
-
 %% Valid request options for get requests. When `if_modified' is
 %% specified with a vclock, the request will fail if the object has
 %% not changed. When `head' is specified, only the metadata will be
@@ -191,3 +190,9 @@
 -type search_schema() :: [{name, binary()} |
                          {content, binary()}].
 
+-record(preflist_item, {
+          partition :: non_neg_integer(),
+          node      :: binary(),
+          primary   :: boolean()
+         }).
+-type preflist() :: [#preflist_item{}].

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-        {riak_pb, "2.0.0.16", {git, "git://github.com/basho/riak_pb", {tag, "2.0.0.16"}}}
+        {riak_pb, "2.1.0.0", {git, "git://github.com/basho/riak_pb", {tag, "2.1.0.0"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.


### PR DESCRIPTION
**Note**: **Bors will fail** on this until a new version is referenced in rebar.config incorporating the update in basho/riak_pb#105 and the riak_core update is reviewed/merged.

### Description

Part of [RIAK-1481](https://bashoeng.atlassian.net/browse/RIAK-1481).

The active preflist will return primary/fallback partitions and nodes for the available nodes at the time of query. Primary/fallback will be annotated.
This involves updates to our RiakKV WB code, RiakPB, Riak-Erlang-Http-Client, Riak-Erlang-Client.

*The impetus for adding this to the API started with a mailing list question answered by Charlie Voiselle, http://lists.basho.com/pipermail/riak-users_lists.basho.com/2015-January/016527.html, which involved a snippet of code that we've given clients multiple times. This was then discussed with Russell Brown on HipChat, https://basho.hipchat.com/history/room/867200/2015/01/13?q=enterprising&t=rid-867200#12:23:22.

Other PRs in the series:

- https://github.com/basho/riak_pb/pull/105
- https://github.com/basho/riak_kv/pull/1083
- https://github.com/basho/riak-erlang-http-client/pull/50