### PR TITLE
Add Bucket types API

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-        {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb", {tag, "2.1.0.2"}}}
+        {riak_pb, "2.1.0.2", {git, "git://github.com/lixen/riak_pb", {branch, "bucket_types"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -3922,7 +3922,7 @@ live_node_tests() ->
                                               primary = true}],
                               Preflist)
              end)},
-    {"creat bucket type",
+    {"create bucket type",
       ?_test(begin
                  reset_riak(),
                  {ok, Pid} = start_link(test_ip(), test_port()),

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1721,11 +1721,11 @@ process_response(#request{msg = #rpbsetbucketreq{}},
     {reply, ok, State};
 
 process_response(#request{msg = #rpbcreatebuckettypereq{}},
-                 rpbsetbucketresp, State) ->
+                 rpbcreatebuckettyperesp, State) ->
     {reply, ok, State};
 
 process_response(#request{msg = #rpbactivatebuckettypereq{}},
-                 rpbsetbucketresp, State) ->
+                 rpbactivatebuckettyperesp, State) ->
     {reply, ok, State};
 
 process_response(#request{msg = #rpbmapredreq{content_type = ContentType}}=Request,


### PR DESCRIPTION
Add support for create and activate bucket types with riak-erlang-client
riakc_pb_socket:create_bucket_type(Pid, BucketType, BucketProps)
riakc_pb_socket:activate_bucket_type(Pid, BucketType)

Created to be used by sumo_db
https://github.com/basho/riak_kv/issues/1123