### PR TITLE
Ensure auto_reconnect if first connect fails

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1261,6 +1261,7 @@ init([Address, Port, Options]) ->
         {error, Reason} when State#state.auto_reconnect /= true ->
             {stop, {tcp, Reason}};
         {error, _Reason} ->
+            erlang:send_after(State#state.reconnect_interval, self(), reconnect),
             {ok, State};
         Ok ->
             Ok


### PR DESCRIPTION
Currently, enabling auto_reconnect only works if the server is up when the client starts.
If the first connect fails, riakc_pb_socket:start_link will return {:ok, pid} but will never auto reconnect.
