### PR TITLE
Fixes for OTP 18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,13 @@
-{require_otp_vsn, "R15|R16|17"}.
+{require_otp_vsn, "R15|R16|17|18"}.
 
 {cover_enabled, true}.
 {eunit_opts, [verbose]}.
-{erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
+{erl_opts, [
+            warnings_as_errors,
+            debug_info,
+            nowarn_deprecated_type,
+            {platform_define, "^[0-9]+", namespaced_types}
+           ]}.
 {deps, [
         {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb", {tag, "2.1.0.2"}}}
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,8 @@
             warnings_as_errors,
             debug_info,
             nowarn_deprecated_type,
-            {platform_define, "^[0-9]+", namespaced_types}
+            {platform_define, "^[0-9]+", namespaced_types},
+            {platform_define, "^18", deprecated_now}
            ]}.
 {deps, [
         {riak_pb, "2.1.0.2", {git, "git://github.com/basho/riak_pb", {tag, "2.1.0.2"}}}

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -130,6 +130,12 @@
 -record(request, {ref :: reference(), msg :: rpb_req(), from, ctx :: ctx(), timeout :: timeout(),
                   tref :: reference() | undefined }).
 
+-ifdef(namespaced_types).
+-type request_queue_t() :: queue:queue(#request{}).
+-else.
+-type request_queue_t() :: queue().
+-endif.
+
 -type portnum() :: non_neg_integer(). %% The TCP port number of the Riak node's Protocol Buffers interface
 -type address() :: string() | atom() | inet:ip_address(). %% The TCP/IP host name or address of the Riak node
 -record(state, {address :: address(),    % address to connect to
@@ -141,7 +147,7 @@
                 keepalive = false :: boolean(), % if true, enabled TCP keepalive for the socket
                 transport = gen_tcp :: 'gen_tcp' | 'ssl',
                 active :: #request{} | undefined,     % active request
-                queue :: queue() | undefined,      % queue of pending requests
+                queue :: request_queue_t() | undefined,      % queue of pending requests
                 connects=0 :: non_neg_integer(), % number of successful connects
                 failed=[] :: [connection_failure()],  % breakdown of failed connects
                 connect_timeout=infinity :: timeout(), % timeout of TCP connection

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -136,6 +136,12 @@
 -type request_queue_t() :: queue().
 -endif.
 
+-ifdef(deprecated_now).
+-define(NOW, erlang:system_time(micro_seconds)).
+-else.
+-define(NOW, erlang:now()).
+-endif.
+
 -type portnum() :: non_neg_integer(). %% The TCP port number of the Riak node's Protocol Buffers interface
 -type address() :: string() | atom() | inet:ip_address(). %% The TCP/IP host name or address of the Riak node
 -record(state, {address :: address(),    % address to connect to
@@ -2187,7 +2193,7 @@ remove_queued_request(Ref, State) ->
     end.
 
 %% @private
-mk_reqid() -> erlang:phash2(erlang:now()). % only has to be unique per-pid
+mk_reqid() -> erlang:phash2(?NOW). % only has to be unique per-pid
 
 %% @private
 wait_for_list(ReqId) ->


### PR DESCRIPTION
Used in https://github.com/esl/MongooseIM/pull/497, makes the library compatible with OTP 18.