### PR TITLE
riak_ts:get now returns {ColumnDescriptions, Rows}

### DIFF
--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -72,7 +72,7 @@ delete(Pid, TableName, Key, Options)
 
 
 -spec get(pid(), table_name(), [ts_value()], proplists:proplist()) ->
-                 [[ts_value()]].
+                 {[binary()], [[ts_value()]]}.
 get(Pid, TableName, Key, Options) ->
     Message = riak_pb_ts_codec:encode_tsgetreq(TableName, Key, Options),
     case server_call(Pid, Message) of

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -77,9 +77,11 @@ get(Pid, TableName, Key, Options) ->
     Message = riak_pb_ts_codec:encode_tsgetreq(TableName, Key, Options),
     case server_call(Pid, Message) of
         {error, {_NotFoundErrCode, <<"notfound">>}} ->
-            [];
+            {[], []};
         Response ->
-            [tuple_to_list(X) || X <- riak_pb_ts_codec:decode_rows(Response#tsgetresp.rows)]
+            Columns = [C || #tscolumndescription{name = C} <- Response#tsgetresp.columns],
+            Rows = [tuple_to_list(X) || X <- riak_pb_ts_codec:decode_rows(Response#tsgetresp.rows)],
+            {Columns, Rows}
     end.
 
 


### PR DESCRIPTION
RTS-480.

Depends on https://github.com/basho/riak_kv/pull/1243 and https://github.com/basho/riak_pb/pull/146.