### PR TITLE
Add docstrings for all riakc_ts external API functions

### DIFF
--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -54,6 +54,11 @@ query(Pid, QueryText) ->
 %%      result returned is a tuple containing a list of columns as
 %%      binaries in the first element, and a list of records, each
 %%      represented as a list of values, in the second element.
+%%
+%%      Note that for the 'float' field type, the actual values
+%%      returned will always be of type double (64-bit), even when the
+%%      data were previously inserted (possibly by some other client)
+%%      in `#tscell.float_value`.
 query(Pid, QueryText, Interpolations) ->
     Message = riakc_ts_query_operator:serialize(QueryText, Interpolations),
     Response = server_call(Pid, Message),
@@ -115,6 +120,11 @@ delete(Pid, TableName, Key, Options)
 %%      1st element, and a record found as a list of values, further
 %%      as a single element in enclosing list, in its 2nd element. If
 %%      no record is found, the return value is {[], []}.
+%%
+%%      Note that for the 'float' field type, the actual values
+%%      returned will always be of type double (64-bit), even when the
+%%      data were previously inserted (possibly by some other client)
+%%      in `#tscell.float_value`.
 get(Pid, TableName, Key, Options) ->
     Message = riak_pb_ts_codec:encode_tsgetreq(TableName, Key, Options),
     case server_call(Pid, Message) of

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -39,11 +39,21 @@
 
 -spec query(pid(), string()) ->
                    {[binary()], [tuple()]} | {error, term()}.
+%% @doc Execute a SELECT query given in a string (2nd argument) with
+%%      client Pid (1st arg).  The result returned is a tuple
+%%      containing a list of columns as binaries in the first element,
+%%      and a list of records, each represented as a list of values,
+%%      in the second element.
 query(Pid, QueryText) ->
     query(Pid, QueryText, []).
 
 -spec query(pid(), string(), [{binary(), binary()}]) ->
                    {[binary()], [tuple()]} | {error, term()}.
+%% @doc Execute a SELECT query given in a string (2nd argument) with
+%%      client Pid (1st arg), using interpolations (3rd arg). The
+%%      result returned is a tuple containing a list of columns as
+%%      binaries in the first element, and a list of records, each
+%%      represented as a list of values, in the second element.
 query(Pid, QueryText, Interpolations) ->
     Message = riakc_ts_query_operator:serialize(QueryText, Interpolations),
     Response = server_call(Pid, Message),
@@ -52,11 +62,29 @@ query(Pid, QueryText, Interpolations) ->
 
 -spec put(pid(), table_name(), [{binary(), ts_value()}]) ->
                  ok | {error, term()}.
+%% @doc Make data records from a list (3rd arg) and insert them, one
+%%      by one, into a TS table (2nd arg), using client Pid (1st
+%%      arg). Each record is a list of values of appropriate types for
+%%      the complete set of table columns, in the order in which they
+%%      appear in table's DDL. Type validation is done on the first
+%%      record only. If any subsequent record contains fewer or more
+%%      elements than there are columns, or some element fails to
+%%      convert to the appropriate type, the rest of the records will
+%%      not get inserted.
 put(Pid, TableName, Measurements) ->
     put(Pid, TableName, [], Measurements).
 
 -spec put(pid(), table_name(), [binary()], [{binary(), ts_value()}]) ->
                  ok | {error, term()}.
+%% @doc Make data records from a list (4th arg) and insert them, one
+%%      by one, into a TS table (2nd arg), using client Pid (1st
+%%      arg). Each record is a list of values of types appropriate for
+%%      the fields mentioned in the column list (3rd arg), in that
+%%      order. Type validation is done on the first record only. If
+%%      any subsequent record contains fewer or more elements than
+%%      there are columns, or some element fails to convert to the
+%%      appropriate type, the rest of the records will not get
+%%      inserted.
 put(Pid, TableName, Columns, Measurements) ->
     Message = riakc_ts_put_operator:serialize(TableName, Columns, Measurements),
     Response = server_call(Pid, Message),
@@ -65,6 +93,12 @@ put(Pid, TableName, Columns, Measurements) ->
 
 -spec delete(pid(), table_name(), [ts_value()], proplists:proplist()) ->
                     ok | {error, term()}.
+%% @doc Delete a record, if there is one, having the fields
+%%      constituting the primary key in the table (2nd arg) equal to
+%%      the composite key (3rd arg, supplied as a list), using client
+%%      Pid (1st arg).  Options (4th arg) is a proplist which can
+%%      include values for 'vclock' and 'timeout'. Unless vclock is
+%%      supplied, a get is called in order to obtain one.
 delete(Pid, TableName, Key, Options)
   when is_list(Key) ->
     Message = riak_pb_ts_codec:encode_tsdelreq(TableName, Key, Options),
@@ -73,6 +107,14 @@ delete(Pid, TableName, Key, Options)
 
 -spec get(pid(), table_name(), [ts_value()], proplists:proplist()) ->
                  {[binary()], [[ts_value()]]}.
+%% @doc Get a record, if there is one, having the fields constituting
+%%      the primary key in the table (2nd arg) equal to the composite
+%%      key (3rd arg, supplied as a list), using client Pid (1st arg).
+%%      Options (4th arg) is a proplist which can include a value for
+%%      'timeout'. Returns a tuple with a list of column names in its
+%%      1st element, and a record found as a list of values, further
+%%      as a single element in enclosing list, in its 2nd element. If
+%%      no record is found, the return value is {[], []}.
 get(Pid, TableName, Key, Options) ->
     Message = riak_pb_ts_codec:encode_tsgetreq(TableName, Key, Options),
     case server_call(Pid, Message) of


### PR DESCRIPTION
Note: For the description of `get/4` to be accurate, https://github.com/basho/riak_kv/pull/1243 and https://github.com/basho/riak-erlang-client/pull/242 need to go first.