### PR TITLE
Add mod_callback to options when start pid

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1251,7 +1251,16 @@ get_preflist(Pid, Bucket, Key, Timeout) ->
 %% ====================================================================
 
 %% @private
-init([Address, Port, Options]) ->
+init([Address, Port, InOptions]) ->
+    %% If callback to sent the startup of the child
+    case proplists:get_value(mod_callback, InOptions) of
+        undefined  -> ok;
+        [Mod, Fun] ->
+            Mod:Fun(self(), Address, Port)
+    end,   
+    
+    Options = proplists:delete(mod_callback, InOptions), 
+
     %% Schedule a reconnect as the first action.  If the server is up then
     %% the handle_info(reconnect) will run before any requests can be sent.
     State = parse_options(Options, #state{address = Address,

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1252,13 +1252,9 @@ get_preflist(Pid, Bucket, Key, Timeout) ->
 
 %% @private
 init([Address, Port, InOptions]) ->
-    %% If callback to sent the startup of the child
-    case proplists:get_value(mod_callback, InOptions) of
-        undefined  -> ok;
-        [Mod, Fun] ->
-            Mod:Fun(self(), Address, Port)
-    end,   
-    
+    %% If callback then send the startup of the child
+    CallbackMod = proplists:get_value(mod_callback, InOptions),   
+ 
     Options = proplists:delete(mod_callback, InOptions), 
 
     %% Schedule a reconnect as the first action.  If the server is up then
@@ -1273,6 +1269,12 @@ init([Address, Port, InOptions]) ->
             erlang:send_after(State#state.reconnect_interval, self(), reconnect),
             {ok, State};
         Ok ->
+            % Only if ok then Mod:Fun
+            case CallbackMod of
+                undefined  -> ok;
+                [Mod, Fun] -> 
+                    Mod:Fun(self(), Address, Port) 
+            end,
             Ok
     end.
 


### PR DESCRIPTION
Hello, 

Recently we upgrade our core application written in erlang that uses riak erlang client with protobuffs, before this upgrade we used a simple load balancer between nodes, so in a simple gen_server a pid is created and kept into the state, but some times the pid will be disconnected and we must connect again.

So for that reason we decide use other strategy, we fork the project riak-erlang-client and decide to make a small change, we add in the options of the start_link function (where pid is created) a new option called: mod_callback, with this we send back the response of the pid, so the callback module knows that a pid was created and then added to the load balancer, all pids are managed by a supervisor, so when a problem occurs the supervisor restart a child and then the option mod_callback notifies to our load balancer so we can keep it into the state.
