### PR TITLE
Fix issues from riak_pb timestamp encoding changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ ebin/*
 /.eqc-info
 /current_counterexample.eqc
 .local_dialyzer_plt
+
+.idea
+*.iml

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -33,6 +33,7 @@
 -include_lib("riak_pb/include/riak_search_pb.hrl").
 -include_lib("riak_pb/include/riak_yokozuna_pb.hrl").
 -include_lib("riak_pb/include/riak_dt_pb.hrl").
+-include_lib("riak_pb/include/riak_ts_pb.hrl").
 -include("riakc.hrl").
 -behaviour(gen_server).
 

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -41,7 +41,7 @@
 
 
 -spec query(Pid::pid(), Query::string()) ->
-                   {ColumnNames::[binary()], Rows::[tuple()]} | {error, Reason::term()}.
+                   {ColumnNames::[ts_columnname()], Rows::[tuple()]} | {error, Reason::term()}.
 %% @doc Execute a "SELECT ..." Query with client.  The result returned
 %%      is a tuple containing a list of columns as binaries in the
 %%      first element, and a list of records, each represented as a
@@ -80,19 +80,19 @@ query(Pid, QueryText, Interpolations) ->
 put(Pid, TableName, Measurements) ->
     put(Pid, TableName, [], Measurements).
 
--spec put(Pid::pid(), Table::table_name(), Columns::[binary()], Data::[[ts_value()]]) ->
+-spec put(Pid::pid(), Table::table_name(), ColumnNames::[ts_columnname()], Data::[[ts_value()]]) ->
                  ok | {error, Reason::term()}.
 %% @doc Make data records from Data and insert them, individually,
 %%      into a time-series Table, using client Pid. Each record is a
 %%      list of values of appropriate types for the complete set of
-%%      table columns, in the order in which they appear in table's
+%%      table column names, in the order in which they appear in table's
 %%      DDL.  On success, 'ok' is returned, else an @{error, Reason@}
 %%      tuple.  Also @see put/3.
 %%
-%%      As of 2015-11-05, Columns parameter is ignored, the function
-%%      expexts the full set of fields in each element of Data.
-put(Pid, TableName, Columns, Measurements) ->
-    Message = riakc_ts_put_operator:serialize(TableName, Columns, Measurements),
+%%      As of 2015-11-05, ColumnNames parameter is ignored, the function
+%%      expects the full set of fields in each element of Data.
+put(Pid, TableName, ColumnNames, Measurements) ->
+    Message = riakc_ts_put_operator:serialize(TableName, ColumnNames, Measurements),
     Response = server_call(Pid, Message),
     riakc_ts_put_operator:deserialize(Response).
 

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -31,10 +31,11 @@
          get/4,
          delete/4]).
 
--include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include_lib("riak_pb/include/riak_ts_pb.hrl").
 
 -type table_name() :: binary().
--type ts_value() :: number() | binary().
+-type ts_value() :: riak_pb_ts_codec:ldbvalue().
+-type ts_columnname() :: riak_pb_ts_codec:tscolumnname().
 
 
 -spec query(pid(), string()) ->
@@ -50,15 +51,15 @@ query(Pid, QueryText, Interpolations) ->
     riakc_ts_query_operator:deserialize(Response).
 
 
--spec put(pid(), table_name(), [{binary(), ts_value()}]) ->
+-spec put(pid(), table_name(), [ts_value()]) ->
                  ok | {error, term()}.
 put(Pid, TableName, Measurements) ->
     put(Pid, TableName, [], Measurements).
 
--spec put(pid(), table_name(), [binary()], [{binary(), ts_value()}]) ->
+-spec put(pid(), table_name(), [ts_columnname()], [ts_value()]) ->
                  ok | {error, term()}.
-put(Pid, TableName, Columns, Measurements) ->
-    Message = riakc_ts_put_operator:serialize(TableName, Columns, Measurements),
+put(Pid, TableName, ColumnsNames, Measurements) ->
+    Message = riakc_ts_put_operator:serialize(TableName, ColumnsNames, Measurements),
     Response = server_call(Pid, Message),
     riakc_ts_put_operator:deserialize(Response).
 

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -25,14 +25,14 @@
 -module(riakc_ts_put_operator).
 
 -include_lib("riak_pb/include/riak_pb.hrl").
--include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include_lib("riak_pb/include/riak_ts_pb.hrl").
 
 -export([serialize/3,
          deserialize/1]).
 
-serialize(TableName, Columns, Measurements) ->
-    SerializedColumns = riak_pb_ts_codec:encode_columns(Columns),
-    SerializedRows = riak_pb_ts_codec:encode_rows(Measurements),
+serialize(TableName, ColumnNames, Measurements) ->
+    SerializedColumns = riak_pb_ts_codec:encode_columnnames(ColumnNames),
+    SerializedRows = riak_pb_ts_codec:encode_rows_non_strict(Measurements),
     #tsputreq{table = TableName,
               columns = SerializedColumns,
               rows = SerializedRows}.

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -25,7 +25,7 @@
 -module(riakc_ts_query_operator).
 
 -include_lib("riak_pb/include/riak_pb.hrl").
--include_lib("riak_pb/include/riak_kv_pb.hrl").
+-include_lib("riak_pb/include/riak_ts_pb.hrl").
 
 -export([serialize/2,
          deserialize/1]).


### PR DESCRIPTION
Use different versions of riak_pb_ts_codec:encode_xxxxx since the originals changed. 
Also fixed some specs here and there. 

This depends on basho/riak_pb#164