### PR TITLE
Feature stats

### DIFF
--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -24,7 +24,7 @@
 -define(PROTO_MAJOR, 1).
 -define(PROTO_MINOR, 0).
 -define(DEFAULT_PB_TIMEOUT, 60000).
--define(FIRST_RECONNECT_INTERVAL, 100).
+-define(FIRST_RECONNECT_INTERVAL, 10).
 -define(MAX_RECONNECT_INTERVAL, 30000).
 
 -type client_option()  :: queue_if_disconnected |

--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -33,7 +33,8 @@
                           auto_reconnect |
                           {auto_reconnect, boolean()} |
                           keepalive |
-                          {keepalive, boolean()}.
+                          {keepalive, boolean()} |
+                          {stats, non_neg_integer()}.
 %% Options for starting or modifying the connection:
 %% `queue_if_disconnected' when present or true will cause requests to
 %% be queued while the connection is down. `auto_reconnect' when

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -3980,23 +3980,23 @@ timeout_no_conn_test() ->
                   end
           end,
 
-    P01 = REQ(get, {150,10}), timer:sleep(1), % sleep to ensure that spawned requests
-    P02 = REQ(get, {100,10}), timer:sleep(1), % are actually sent in this order
-    P03 = REQ(get, {150,10}), timer:sleep(1),
-    P04 = REQ(get, {100,10}), timer:sleep(1),
-    P05 = REQ(get, {150,10}), timer:sleep(1),
-    P06 = REQ(get, {100,10}), timer:sleep(1),
-    P07 = REQ(get, {150,10}), timer:sleep(1),
-    P08 = REQ(get, {100,10}), timer:sleep(1),
-    P09 = REQ(get, {150,10}), timer:sleep(1),
-    P10 = REQ(get, 20),       timer:sleep(1),
-    P11 = REQ(get, 40),       timer:sleep(1),
-    P12 = REQ(get, 60),       timer:sleep(1),
-    P13 = REQ(get, 80),       timer:sleep(1),
-    P14 = REQ(get, 20),       timer:sleep(1),
-    P15 = REQ(get, 100),      timer:sleep(250), 0 = queue_len(Pid),
-    P16 = REQ(get, {20,100}), timer:sleep(1),
-    P17 = REQ(get, {20,100}),
+    P01 = REQ(get, {1500,100}), timer:sleep(1), % sleep to ensure that spawned requests
+    P02 = REQ(get, {1000,100}), timer:sleep(1), % are actually sent in this order
+    P03 = REQ(get, {1500,100}), timer:sleep(1),
+    P04 = REQ(get, {1000,100}), timer:sleep(1),
+    P05 = REQ(get, {1500,100}), timer:sleep(1),
+    P06 = REQ(get, {1000,100}), timer:sleep(1),
+    P07 = REQ(get, {1500,100}), timer:sleep(1),
+    P08 = REQ(get, {1000,100}), timer:sleep(1),
+    P09 = REQ(get, {1500,100}), timer:sleep(1),
+    P10 = REQ(get, 200),        timer:sleep(1),
+    P11 = REQ(get, 400),        timer:sleep(1),
+    P12 = REQ(get, 600),        timer:sleep(1),
+    P13 = REQ(get, 800),        timer:sleep(1),
+    P14 = REQ(get, 200),        timer:sleep(1),
+    P15 = REQ(get, 1000),       timer:sleep(2500), 0 = queue_len(Pid),
+    P16 = REQ(get, {200,1000}), timer:sleep(1),
+    P17 = REQ(get, {200,1000}),
 
     {T01, {error, timeout}} = RES(P01),
     {T02, {error, timeout}} = RES(P02),
@@ -4016,26 +4016,26 @@ timeout_no_conn_test() ->
     {T16, {error, timeout}} = RES(P16),
     {T17, {error, timeout}} = RES(P17),
 
-    % All these requests should spend ~150ms in the queue
+    % All these requests should spend ~1500ms in the queue
     io:format(user, "150ms TIMES: ~p ~p ~p ~p ~p~n", [T01,T03,T05,T07,T09]),
-    lists:foreach(fun(T) -> true = T > 145, true = T < 159 end, [T01,T03,T05,T07,T09]),
+    lists:foreach(fun(T) -> true = T > 1490, true = T < 1510 end, [T01,T03,T05,T07,T09]),
 
-    % All these requests should spend ~100ms in the queue
+    % All these requests should spend ~1000ms in the queue
     io:format(user, "100ms TIMES: ~p ~p ~p ~p~n", [T02,T04,T06,T08]),
-    lists:foreach(fun(T) -> true = T > 95,  true = T < 109 end, [T02,T04,T06,T08]),
+    lists:foreach(fun(T) -> true = T > 990,  true = T < 1010 end, [T02,T04,T06,T08]),
 
     % These test the old timeouts
     io:format(user, "TIMES: ~p ~p ~p ~p ~p ~p ~p ~p~n", [T10,T11,T12,T13,T14,T15,T16,T17]),
-    true = T10 > 18, true = T10 < 25,
-    true = T11 > 37, true = T11 < 45,
-    true = T12 > 55, true = T12 < 65,
-    true = T13 > 73, true = T13 < 85,
-    true = T14 > 18, true = T14 < 25,
-    true = T15 > 98, true = T15 < 105,
+    true = T10 > 190, true = T10 < 210,
+    true = T11 > 390, true = T11 < 410,
+    true = T12 > 590, true = T12 < 610,
+    true = T13 > 790, true = T13 < 810,
+    true = T14 > 190, true = T14 < 210,
+    true = T15 > 990, true = T15 < 1010,
 
-    % These 2 requests should spend ~20ms in the queue
-    true = T16 > 18, true = T16 < 25,
-    true = T17 > 18, true = T17 < 25,
+    % These 2 requests should spend ~200ms in the queue
+    true = T16 > 190, true = T16 < 210,
+    true = T17 > 190, true = T17 < 210,
 
     stop(Pid).
 
@@ -4047,7 +4047,7 @@ timeout_conn_test() ->
     % so the test is variable, it may fail the first time but try it again
 
     % Set up a dummy socket to send requests on
-    {ok, DummyServerPid, Port} = dummy_server(),
+    {ok, DummyServerPid, Port} = dummy_server(noreply),
     {ok, Pid} = start("127.0.0.1", Port, [auto_reconnect, queue_if_disconnected]),
     erlang:monitor(process, DummyServerPid),
     Self = self(),
@@ -4067,24 +4067,24 @@ timeout_conn_test() ->
                   end
           end,
 
-    P01 = REQ(get, {100, 20}), timer:sleep(1), % sleep to ensure that spawned requests
-    P02 = REQ(get, {100, 20}), timer:sleep(1), % are actually sent in this order
-    P03 = REQ(get, {100, 20}), timer:sleep(1),
-    P04 = REQ(get, {100, 20}), timer:sleep(1),
-    P05 = REQ(get, {100, 20}), timer:sleep(1),
-    P06 = REQ(get, {100, 20}), timer:sleep(1),
-    P07 = REQ(get, {100, 20}), timer:sleep(1),
-    P08 = REQ(get, {100, 20}), timer:sleep(1),
-    P09 = REQ(get, {100, 20}), timer:sleep(1),
-    P10 = REQ(get, {100, 20}), timer:sleep(1),
-    P11 = REQ(get, 20),        timer:sleep(1),
-    P12 = REQ(get, 40),        timer:sleep(1),
-    P13 = REQ(get, 60),        timer:sleep(1),
-    P14 = REQ(get, 80),        timer:sleep(1),
-    P15 = REQ(get, 20),        timer:sleep(1),
-    P16 = REQ(get, 100),       timer:sleep(200), 0 = queue_len(Pid),
-    P17 = REQ(get, {20, 100}), timer:sleep(1),
-    P18 = REQ(get, {20, 100}),
+    P01 = REQ(get, {1000, 200}), timer:sleep(1), % sleep to ensure that spawned requests
+    P02 = REQ(get, {1000, 200}), timer:sleep(1), % are actually sent in this order
+    P03 = REQ(get, {1000, 200}), timer:sleep(1),
+    P04 = REQ(get, {1000, 200}), timer:sleep(1),
+    P05 = REQ(get, {1000, 200}), timer:sleep(1),
+    P06 = REQ(get, {1000, 200}), timer:sleep(1),
+    P07 = REQ(get, {1000, 200}), timer:sleep(1),
+    P08 = REQ(get, {1000, 200}), timer:sleep(1),
+    P09 = REQ(get, {1000, 200}), timer:sleep(1),
+    P10 = REQ(get, {1000, 200}), timer:sleep(1),
+    P11 = REQ(get, 200),         timer:sleep(1),
+    P12 = REQ(get, 400),         timer:sleep(1),
+    P13 = REQ(get, 600),         timer:sleep(1),
+    P14 = REQ(get, 800),         timer:sleep(1),
+    P15 = REQ(get, 200),         timer:sleep(1),
+    P16 = REQ(get, 1000),        timer:sleep(2000), 0 = queue_len(Pid),
+    P17 = REQ(get, {200, 1000}), timer:sleep(1),
+    P18 = REQ(get, {200, 1000}),
 
     {T01, {error, timeout}} = RES(P01),
     {T02, {error, timeout}} = RES(P02),
@@ -4107,25 +4107,28 @@ timeout_conn_test() ->
 
     io:format(user, "TIMES: ~p ~p ~p ~p ~p ~p ~p ~p ~p ~p ~p ~p ~p ~p ~p ~p ~p ~p~n",
               [T01,T02,T03,T04,T05,T06,T07,T08,T09,T10,T11,T12,T13,T14,T15,T16,T17,T18]),
-    true = T01 > 18, true = T01 < 26, % This one is serviced right away & should timeout after 20ms
-    true = T02 > 37, true = T02 < 49, % This one is serviced after the 1st one has timed out, ~40ms
-    true = T03 > 55, true = T03 < 70, % This one is serviced after the 1st two have timed out, ~60ms
-    true = T04 > 73, true = T04 < 90, % This one is serviced after the 1st three have timed out, ~80ms
-    true = T05 > 91, true = T05 < 117, % This one might timeout inthe q, or might be serviced
+    true = T01 > 190, true = T01 < 210, % This one is serviced right away & should timeout after 200ms
+    true = T02 > 390, true = T02 < 410, % This one is serviced after the 1st one has timed out, ~400ms
+    true = T03 > 590, true = T03 < 610, % This one is serviced after the 1st two have timed out, ~600ms
+    true = T04 > 790, true = T04 < 810, % This one is serviced after the 1st three have timed out, ~800ms
+    true = T05 > 990, true = T05 < 1010, % This one is serviced after the 1st four have timed out, ~1000ms
 
-    % All these will timeout in the queue
-    lists:foreach(fun(T) -> true = T > 97, true = T < 125 end, [T06,T07,T08,T09,T10]),
+    [HD|TL] = lists:reverse(lists:sort([T06,T07,T08,T09,T10])),
+    % One will have queued & been serviced, ~1200ms
+    true = HD > 1190, true = HD < 1210,
+    % All these will timeout in the queue, ~1000ms
+    lists:foreach(fun(T) -> true = T > 990, true = T < 1010 end, TL),
 
     % These test for backward compatibility
-    true = T11 > 17, true = T11 < 25,
-    true = T12 > 37, true = T12 < 48,
-    true = T13 > 57, true = T13 < 70,
-    true = T14 > 77, true = T14 < 90,
-    true = T15 > 17, true = T15 < 26,
-    true = T16 > 97, true = T16 < 106,
+    true = T11 > 190, true = T11 < 210,
+    true = T12 > 390, true = T12 < 410,
+    true = T13 > 590, true = T13 < 610,
+    true = T14 > 790, true = T14 < 810,
+    true = T15 > 190, true = T15 < 210,
+    true = T16 > 990, true = T16 < 1010,
 
-    true = T17 > 97, true = T17 < 106,  % This one will be serviced right away & timeout after ~100ms
-    true = T18 > 17, true = T18 < 26,   % This one will timeout in the queue waiting for the previous one ~20ms
+    true = T17 > 990, true = T17 < 1010,  % This one will be serviced right away & timeout after ~100ms
+    true = T18 > 190, true = T18 < 210,   % This one will timeout in the queue waiting for the previous one ~20ms
 
     catch DummyServerPid ! stop,
     timer:sleep(10),

--- a/src/riakc_stats.erl
+++ b/src/riakc_stats.erl
@@ -1,0 +1,230 @@
+-module(riakc_stats).
+-export([stats_format/1,
+         init_stats/1,
+         record_stat/3,
+         record_cntr/2,
+         merge_stats/2,
+         print/1]).
+
+-export([time/1,
+         bytes/1]).
+
+-record(stats, {timestamp, level, dict}).
+
+record_cntr(_Key, #stats{level = 0} = Stats) ->
+    Stats;
+record_cntr(Key, #stats{dict = D} = Stats) ->
+    Stats#stats{dict = dict:update_counter({count, Key}, 1, D)}.
+
+record_stat(_Key, _Val, #stats{level = 0} = Stats) ->
+    Stats;
+record_stat(Key, Val, #stats{dict = Dict0, level = 1} = Stats) ->
+    Dict1 = dict:update_counter({count, Key}, 1, Dict0),
+    Stats#stats{dict = dict:update_counter({total, Key}, Val, Dict1)};
+record_stat(Key, Val, #stats{dict = Dict0, level = 2} = Stats) ->
+    Dict1 = dict:update_counter({count, Key}, 1, Dict0),
+    Dict2 = dict:update_counter({total, Key}, Val, Dict1),
+    Stats#stats{dict = dict:update_counter({histogram, granulate(Val), Key}, 1, Dict2)}.
+
+init_stats(#stats{level = Level}) ->
+    init_stats(Level);
+init_stats(Level) ->
+    #stats{timestamp = os:timestamp(), level = Level, dict = dict:new()}.
+
+stats_format(#stats{timestamp = TS0, level = Level, dict = Dict}) ->
+    TS1 = os:timestamp(),
+    TDiff = timer:now_diff(TS1, TS0),
+    {Cntrs, Hists} = stats_format(
+                       Level, lists:sort(dict:to_list(Dict)), [],
+                       [{key, count, total, lists:reverse(steps(Level))}]),
+    {{TDiff, 1}, Cntrs, Hists}.
+
+stats_format(_Level, [], CAcc, HAcc) -> {CAcc, HAcc};
+stats_format(Level, [{{count, Key}, CVal} | List], CAcc, HAcc) ->
+    case lists:keytake({total, Key}, 1, List) of
+        false -> stats_format(Level, List, [{Key, CVal} | CAcc], HAcc);
+        {value, {{total, Key}, TVal}, NewList} ->
+            {OutList, Histogram} =
+                lists:foldl(fun(I, {LAcc, XAcc}) ->
+                                    case lists:keytake({histogram, I, Key}, 1, LAcc) of
+                                        false -> {LAcc, [0 | XAcc]};
+                                        {value, {{_, _, Key}, HVal}, LAcc2} -> {LAcc2, [HVal | XAcc]}
+                                    end
+                            end, {NewList, []}, steps(Level)),
+            stats_format(Level, OutList, CAcc, [{Key, CVal, TVal, Histogram} | HAcc])
+    end.
+
+granulate(0)                     -> 0;
+granulate(1)                     -> 1;
+granulate(2)                     -> 2;
+granulate(N) when N =< 4         -> 4;
+granulate(N) when N =< 7         -> 7;
+granulate(N) when N =< 10        -> 10;
+granulate(N) when N =< 20        -> 20;
+granulate(N) when N =< 40        -> 40;
+granulate(N) when N =< 70        -> 70;
+granulate(N) when N =< 100       -> 100;
+granulate(N) when N =< 200       -> 200;
+granulate(N) when N =< 400       -> 400;
+granulate(N) when N =< 700       -> 700;
+granulate(N) when N =< 1000      -> 1000;
+granulate(N) when N =< 2000      -> 2000;
+granulate(N) when N =< 4000      -> 4000;
+granulate(N) when N =< 7000      -> 7000;
+granulate(N) when N =< 10000     -> 10000;
+granulate(N) when N =< 20000     -> 20000;
+granulate(N) when N =< 40000     -> 40000;
+granulate(N) when N =< 70000     -> 70000;
+granulate(N) when N =< 100000    -> 100000;
+granulate(N) when N =< 200000    -> 200000;
+granulate(N) when N =< 400000    -> 400000;
+granulate(N) when N =< 700000    -> 700000;
+granulate(N) when N =< 1000000   -> 1000000;
+granulate(N) when N =< 2000000   -> 2000000;
+granulate(N) when N =< 4000000   -> 4000000;
+granulate(N) when N =< 7000000   -> 7000000;
+granulate(N) when N =< 10000000  -> 10000000;
+granulate(N) when N =< 20000000  -> 20000000;
+granulate(N) when N =< 40000000  -> 40000000;
+granulate(N) when N =< 70000000  -> 70000000;
+granulate(N) when N =< 100000000 -> 100000000;
+granulate(N) when N =< 200000000 -> 200000000;
+granulate(N) when N =< 400000000 -> 400000000;
+granulate(N) when N =< 700000000 -> 700000000;
+granulate(_)                     -> 1000000000.
+
+steps(2) ->
+    [1000000000,
+     700000000, 400000000, 200000000, 100000000,
+     70000000, 40000000, 20000000, 10000000,
+     7000000, 4000000, 2000000, 1000000,
+     700000, 400000, 200000, 100000,
+     70000, 40000, 20000, 10000,
+     7000, 4000, 2000, 1000,
+     700, 400, 200, 100,
+     70, 40, 20, 10,
+     7, 4, 2, 1,
+     0];
+steps(_) -> [].
+
+merge_stats({{TAcc1, TCnt1}, Cntrs1, HistG1}, {{TAcc2, TCnt2}, Cntrs2, HistG2}) ->
+    {{TAcc1 + TAcc2, TCnt1 + TCnt2}, add_cntrs(Cntrs1, Cntrs2, []), add_hists(HistG1, HistG2, [])}.
+
+add_cntrs([], [], Acc) -> Acc;
+add_cntrs([], Cntrs2, Acc) -> lists:append([Cntrs2, Acc]);
+add_cntrs(Cntrs1, [], Acc) -> lists:append([Cntrs1, Acc]);
+add_cntrs([{Cntr, Val1} = Cntr1 | Cntrs1], Cntrs2, Acc) ->
+    case lists:keytake(Cntr, 1, Cntrs2) of
+        false ->
+            add_cntrs(Cntrs1, Cntrs2, [Cntr1 | Acc]);
+        {value, {Cntr, Val2}, NewCntrs2} ->
+            add_cntrs(Cntrs1, NewCntrs2, [{Cntr, Val1 + Val2} | Acc])
+    end.
+
+add_hists([], [], Acc) -> Acc;
+add_hists([], Hists2, Acc) -> lists:append([Hists2, Acc]);
+add_hists(Hists1, [], Acc) -> lists:append([Hists1, Acc]);
+add_hists([{key, _, _, _} = HistRec | Hists1], Hists2, Acc) ->
+    add_hists(Hists1, lists:keydelete(key, 1, Hists2), [HistRec | Acc]);
+add_hists([{Key, Cntr1, Ttl1, Hist1} = HistRec1 | Hists1], Hists2, Acc) ->
+    case lists:keytake(Key, 1, Hists2) of
+        false ->
+            add_hists(Hists1, Hists2, [HistRec1 | Acc]);
+        {value, {Key, Cntr2, Ttl2, Hist2}, NewHists2} ->
+            add_hists(Hists1, NewHists2, [{Key, Cntr1 + Cntr2, Ttl1 + Ttl2, add_hist(Hist1, Hist2, [])} | Acc])
+    end.
+
+add_hist([], [], Acc) -> lists:reverse(Acc);
+add_hist([H1 | Hist1], [H2 | Hist2], Acc) ->
+    add_hist(Hist1, Hist2, [H1 + H2 | Acc]).
+
+print({{Time, Conns}, Cntrs, Hists}) ->
+    io:format(user,
+              "~n~nRiak Connection Stats"
+              "~n connections established: ~p"
+              "~n stat monitoring period: " ++ time(Time div Conns) ++ "~n",
+              [Conns]),
+    lists:foreach(fun({Key, Cnt}) ->
+                          print_cntr_key(Key, Cnt)
+                  end, Cntrs),
+    {value,{key,_,_,KeyDivs}, RestHists} =
+        lists:keytake(key, 1, Hists),
+    lists:foreach(fun({Key, Cnt, Ttl, Divs}) ->
+                          TypeFunc = print_hist_key(Key, Cnt, Ttl),
+                          print_hist(TypeFunc, 0, Divs, KeyDivs)
+                  end, RestHists),
+    io:format(user, "~n~n", []).
+
+print_hist_key(send, Cnt, Ttl) ->
+    io:format(user,
+              "~n~n data sent: " ++ bytes(Ttl) ++
+              "~n packets: ~p"
+              "~n average packet size: " ++ bytes(Ttl div Cnt),
+              [Cnt]),
+    bytes;
+print_hist_key(recv, Cnt, Ttl) ->
+    io:format(user,
+              "~n~n data received: " ++ bytes(Ttl) ++
+              "~n packets: ~p"
+              "~n average packet size: " ++ bytes(Ttl div Cnt),
+              [Cnt]),
+    bytes;
+print_hist_key(connect, Cnt, Ttl) ->
+    io:format(user,
+              "~n~n reconnections: ~p"
+              "~n average reconnect time: " ++ time(Ttl div Cnt),
+              [Cnt]),
+    time;
+print_hist_key({service_time, OpTimeout, OpType, BucketName}, Cnt, Ttl) ->
+    io:format(user,
+              "~n~n ~p ~p operations on bucket: ~p"
+              "~n with timeout: ~p"
+              "~n average service time: " ++ time(Ttl div Cnt),
+              [Cnt, OpType, BucketName, OpTimeout]),
+    time;
+print_hist_key({queue_time, QTimeout}, Cnt, Ttl) ->
+    io:format(user,
+              "~n~n ~p requests got queued with timeout: ~p"
+              "~n average queueing time: " ++ time(Ttl div Cnt),
+              [Cnt, QTimeout]),
+    time.
+
+time(Val) when Val < 1000 ->
+    integer_to_list(Val) ++ " us";
+time(Val) when Val < 1000000 ->
+    integer_to_list(Val div 1000) ++ " ms";
+time(Val) ->
+    integer_to_list(Val div 1000000) ++ " s".
+
+bytes(Val) when Val < 1000 ->
+    integer_to_list(Val) ++ " B";
+bytes(Val) when Val < 1000000 ->
+    integer_to_list(Val div 1000) ++ " KB";
+bytes(Val) when Val < 1000000000 ->
+    integer_to_list(Val div 1000000) ++ " MB";
+bytes(Val) ->
+    integer_to_list(Val div 1000000000) ++ " GB".
+
+
+print_hist(_TypeFunc, _PredDiv, [], []) -> ok;
+print_hist(TypeFunc, _PredDiv, [0|Divs], [D|KeyDivs]) ->
+    print_hist(TypeFunc, D, Divs, KeyDivs);
+print_hist(TypeFunc, PredDiv, [N|Divs], [D|KeyDivs]) ->
+    io:format(user,
+              "~n  ~p between " ++ apply(?MODULE, TypeFunc, [PredDiv])
+              ++ " and " ++ apply(?MODULE, TypeFunc, [D]), [N]),
+    print_hist(TypeFunc, D, Divs, KeyDivs).
+
+print_cntr_key({TimeoutTag, Timeout, OPType, BucketName}, Cnt)
+  when TimeoutTag == op_timeout; TimeoutTag == req_timeout ->
+    io:format(user, "~n ~p ~p requests on bucket: ~p timed out while being serviced, timeout: ~p.~n",
+              [Cnt, OPType, BucketName, Timeout]);
+print_cntr_key({TimeoutTag, Timeout, BucketName}, Cnt)
+  when TimeoutTag == q_timeout; TimeoutTag == req_timeout ->
+    io:format(user,
+              "~n ~p requests on bucket: ~p timed out while in the queue, timeout: ~p.~n",
+              [Cnt, BucketName, Timeout]);
+print_cntr_key({queue_len, QLen}, Cnt) ->
+    io:format(user,
+              "~n on ~p occassions the queue was ~p requests long when new requests were added.~n",
+              [Cnt, QLen]).


### PR DESCRIPTION
This pull request adds some statistics gathering to the riakc client. In our applications we've found that the server side stats didn't provide us with a full picture as NW latency is a significant part of the whole request time.

stats_demo_test gives a quick sanity check of the functionality but here's an example use-case with a snippet of output data from our live system (sensitive info blanked out) to see its real value:

Assuming you have a variable PidList with the pids of all the clients in the system, set the stats level to 2 with:
lists:foreach(fun(Pid) -> riakc_pb_socket:stats_change_level(Pid, 2) end, PidList).

Then after some time grab all the collected stats with:
FullStat = lists:foldl(fun(Pid,StatAcc) -> riakc_stats:merge(StatAcc,riakc_pb_socket:stats_peek(Pid)) end, riakc_pb_socket:stats_peek(hd(PidList)), tl(PidList)).


Then format the raw stats data with:
riakc_stats:print(FullStat).


Riak Connection Stats
 connections established: 200
 stat monitoring period: 260 s

 2 put requests on bucket: <<"bucket1">> timed out while being serviced, timeout: 500.

 on 6 occassions the queue was 1 requests long when new requests were added.

 1 get requests on bucket: <<"bucket2">> timed out while being serviced, timeout: 500.


 24454 put operations on bucket: <<"bucket1">>
 with timeout: 500
 average service time: 15 ms
  7009 between 7 ms and 10 ms
  16574 between 10 ms and 20 ms
  535 between 20 ms and 40 ms
  192 between 40 ms and 70 ms
  39 between 70 ms and 100 ms
  30 between 100 ms and 200 ms
  74 between 200 ms and 400 ms
  1 between 400 ms and 700 ms

 47329 get operations on bucket: <<"bucket1">>
 with timeout: 500
 average service time: 13 ms
  20718 between 7 ms and 10 ms
  25595 between 10 ms and 20 ms
  658 between 20 ms and 40 ms
  179 between 40 ms and 70 ms
  44 between 70 ms and 100 ms
  48 between 100 ms and 200 ms
  86 between 200 ms and 400 ms
  1 between 400 ms and 700 ms

 data sent: 19 MB
 packets: 119449
 average packet size: 165 B
  94679 between 20 B and 40 B
  274 between 40 B and 70 B
  22 between 100 B and 200 B
  39 between 200 B and 400 B
  17495 between 400 B and 700 B
  2009 between 700 B and 1 KB
  4794 between 1 KB and 2 KB
  83 between 2 KB and 4 KB
  54 between 4 KB and 7 KB

 data received: 69 MB
 packets: 119442
 average packet size: 580 B
  24792 between 0 B and 1 B
  196 between 100 B and 200 B
  2620 between 200 B and 400 B
  67329 between 400 B and 700 B
  3852 between 700 B and 1 KB
  20325 between 1 KB and 2 KB
  215 between 2 KB and 4 KB
  113 between 4 KB and 7 KB

 reconnections: 3
 average reconnect time: 914 us
  2 between 700 us and 1 ms
  1 between 1 ms and 2 ms

 6 requests got queued with timeout: 1000
 average queueing time: 65 ms
  1 between 10 ms and 20 ms
  2 between 20 ms and 40 ms
  1 between 70 ms and 100 ms
  2 between 100 ms and 200 ms
