### PR TITLE
use streaming list_keys for TS

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -97,6 +97,8 @@
          update_type/4, update_type/5,
          modify_type/5]).
 
+%% supporting functions used in riakc_ts
+-export([mk_reqid/0]).
 
 -deprecated({get_index,'_', eventually}).
 

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -2315,7 +2315,7 @@ remove_queued_request(Ref, State) ->
     end.
 
 %% @private
-mk_reqid() -> erlang:phash2(erlang:now()). % only has to be unique per-pid
+mk_reqid() -> erlang:phash2(crypto:rand_bytes(10)). % only has to be unique per-pid
 
 %% @private
 wait_for_list(ReqId) ->


### PR DESCRIPTION
RTS-697. Depends on https://github.com/basho/riak_kv/pull/1291.

This PR introduces `riakc_ts:stream_list_keys/3` and scraps `riakc_ts:list_keys/3`.