### PR TITLE
new API function riakc_ts:describe_table/1

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1952,6 +1952,15 @@ process_response(#request{msg = #rpbgetbucketkeypreflistreq{}},
               || T <- Preflist],
     {reply, {ok, Result}, State};
 
+process_response(#request{msg = #tsddlschemareq{}},
+                 tsddlschemaresp, State) ->
+    {reply, #tsddlschemareq{}, State};
+
+process_response(#request{msg = #tsddlschemareq{}},
+                 Result = #tsddlschemaresp{},
+                 State) ->
+    {reply, Result, State};
+
 process_response(#request{msg = #tsputreq{}},
                  tsputresp, State) ->
     {reply, ok, State};


### PR DESCRIPTION
RTS-568

Requires https://github.com/basho/riak_pb/pull/174.

Uses TsDdlSchemaReq/-Resp PB messages to get the DDL schema used to
create a table