### PR TITLE
Perf/ttb newmsg ts1.0 release candidate v2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-		{riak_pb, "2.1.1.0", {git, "git://github.com/basho/riak_pb", {branch, "perf/ttb_newmsg_ts1.0"}}}
+		{riak_pb, "2.1.1.0", {git, "git://github.com/basho/riak_pb", {branch, "perf/ttb_newmsg_ts1.0_release_candidate"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-		{riak_pb, "2.1.1.0", {git, "git://github.com/basho/riak_pb", {branch, "perf/ttb_newmsg_ts1.0_release_candidate"}}}
+		{riak_pb, "2.1.1.0", {git, "git://github.com/basho/riak_pb", {tag, "2.1.1.0"}}} 
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,8 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-		{riak_pb, "2.1.1.0", {git, "git://github.com/basho/riak_pb", {tag, "2.1.1.0"}}} 
+		{riak_pb, ".*",      {git, "git://github.com/basho/riak_pb.git", {branch, "end-to-end/timeseries"}}}
+
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -38,8 +38,6 @@
 -include("riakc.hrl").
 -behaviour(gen_server).
 
--compile([{parse_transform, lager_transform}]).
-
 -export([start_link/2, start_link/3,
          start/2, start/3,
          stop/1,

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1965,7 +1965,7 @@ process_response(#request{msg = #tsputreq{}},
                  tsputresp, State) ->
     {reply, ok, State};
 
-process_response(#request{msg = #tsttbputreq{}},
+process_response(#request{msg = #tsputreqttb{}},
                  tsputresp, State) ->
     {reply, ok, State};
 

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1965,7 +1965,7 @@ process_response(#request{msg = #tsputreq{}},
                  tsputresp, State) ->
     {reply, ok, State};
 
-process_response(#request{msg = #tsputreqttb{}},
+process_response(#request{msg = #tsttbputreq{}},
                  tsputresp, State) ->
     {reply, ok, State};
 

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -92,10 +92,10 @@ put(Pid, TableName, Measurements) ->
 %%      As of 2015-11-05, ColumnNames parameter is ignored, the function
 %%      expects the full set of fields in each element of Data.
 put(Pid, TableName, ColumnNames, Measurements) ->
-    Message = riakc_ts_put_operator:serialize(TableName, ColumnNames, Measurements),
-    Response = server_call(Pid, Message),
+    UseNativeEncoding = get(pb_use_native_encoding),
+    Message = riakc_ts_put_operator:serialize(UseNativeEncoding, TableName, ColumnNames, Measurements),
+    Response = server_call(UseNativeEncoding, Pid, Message),
     riakc_ts_put_operator:deserialize(Response).
-
 
 -spec delete(Pid::pid(), Table::table_name(), Key::[ts_value()],
              Options::proplists:proplist()) ->
@@ -168,4 +168,9 @@ stream_list_keys(Pid, Table, Options) ->
 server_call(Pid, Message) ->
     gen_server:call(Pid,
                     {req, Message, riakc_pb_socket:default_timeout(timeseries)},
+                    infinity).
+
+server_call(UseNativeEncoding, Pid, Message) ->
+    gen_server:call(Pid,
+                    {req, UseNativeEncoding, Message, riakc_pb_socket:default_timeout(timeseries)},
                     infinity).

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -92,7 +92,7 @@ put(Pid, TableName, Measurements) ->
 %%      As of 2015-11-05, ColumnNames parameter is ignored, the function
 %%      expects the full set of fields in each element of Data.
 put(Pid, TableName, ColumnNames, Measurements) ->
-    Message = riakc_ts_put_operator:serialize_for_ttb(TableName, ColumnNames, Measurements),
+    Message = riakc_ts_put_operator:serialize(TableName, ColumnNames, Measurements),
     Response = server_call(Pid, Message),
     riakc_ts_put_operator:deserialize(Response).
 

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -36,18 +36,19 @@
 
 serialize(TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
-    case get(pb_use_native_encoding) of
-        true ->
-	    SerializedRows = riak_pb_ts_codec:encode_rows_for_ttb(Measurements),
-	    #tsttbputreq{table   = TableName,
-			 columns = ColumnDescs,
-			 rows    = SerializedRows};
-	_ ->
-	    SerializedRows = riak_pb_ts_codec:encode_rows_non_strict(Measurements),
-	    #tsputreq{table   = TableName,
-		      columns = ColumnDescs,
-		      rows    = SerializedRows}
-    end.
+    serialize(get(pb_use_native_encoding), TableName, ColumnDescs, Measurements).
+
+serialize(true, TableName, ColumnDescs, Measurements) ->
+    SerializedRows = riak_pb_ts_codec:encode_rows_for_ttb(Measurements),
+    #tsttbputreq{table   = TableName,
+                 columns = ColumnDescs,
+		 rows    = SerializedRows};
+
+serialize(false, TableName, ColumnDescs, Measurements) ->
+    SerializedRows = riak_pb_ts_codec:encode_rows_non_strict(Measurements),
+    #tsputreq{table   = TableName,
+              columns = ColumnDescs,
+              rows    = SerializedRows}.
 
 deserialize(Response) ->
     Response.

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -37,7 +37,7 @@
 serialize(true, TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
     SerializedRows = riak_pb_ts_codec:encode_rows_for_ttb(Measurements),
-    #tsttbputreq{table   = TableName,
+    #tsputreqttb{table   = TableName,
                  columns = ColumnDescs,
 		 rows    = SerializedRows};
 

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -44,7 +44,7 @@ serialize(true, TableName, ColumnDescs, Measurements) ->
                  columns = ColumnDescs,
 		 rows    = SerializedRows};
 
-serialize(false, TableName, ColumnDescs, Measurements) ->
+serialize(_, TableName, ColumnDescs, Measurements) ->
     SerializedRows = riak_pb_ts_codec:encode_rows_non_strict(Measurements),
     #tsputreq{table   = TableName,
               columns = ColumnDescs,

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -27,24 +27,22 @@
 -include_lib("riak_pb/include/riak_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 
--export([serialize/3,
+-export([serialize/4,
          deserialize/1]).
 
 %% serialize uses the process dictionary to check if native encoding
 %% should be used.  If true (ttb encoding) call encode_rows_for_ttb.
 %% If false, call default pb encoding function.
 
-serialize(TableName, ColumnNames, Measurements) ->
+serialize(true, TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
-    serialize(get(pb_use_native_encoding), TableName, ColumnDescs, Measurements).
-
-serialize(true, TableName, ColumnDescs, Measurements) ->
     SerializedRows = riak_pb_ts_codec:encode_rows_for_ttb(Measurements),
     #tsttbputreq{table   = TableName,
                  columns = ColumnDescs,
 		 rows    = SerializedRows};
 
-serialize(_, TableName, ColumnDescs, Measurements) ->
+serialize(_, TableName, ColumnNames, Measurements) ->
+    ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
     SerializedRows = riak_pb_ts_codec:encode_rows_non_strict(Measurements),
     #tsputreq{table   = TableName,
               columns = ColumnDescs,

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -37,7 +37,7 @@
 serialize(true, TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
     SerializedRows = riak_pb_ts_codec:encode_rows_for_ttb(Measurements),
-    #tsputreqttb{table   = TableName,
+    #tsttbputreq{table   = TableName,
                  columns = ColumnDescs,
 		 rows    = SerializedRows};
 


### PR DESCRIPTION
This is one of three related PRs (basho/riak_kv#1323 is the corresponding PR for riak_kv, basho/riak_pb#176 is the corresponding one for riak_pb), to streamline put requests using TTB encoding instead of PB.
As with the current end-to-end/timeseries branch, the TTB encoded messages are still handled by the riak_kv_pb service; even though they are not PB-encoded messages, they reuse the erlang infrastructure around generating erlang messages from the .proto definitions.

Changes include:

1) riakc_ts.erl put operator has been modified to lookup encoding method in the process dict and pass this as an argument to serialization and encoding methods.  Additional server_call method has been added to propagate this to riakc_pb_socket where the encoding is done

2) added handle_call methods to riakc_pb_socket that pattern-match on value of pb_use_native_encoding.  If true, TTB is used.  If false or undefined (default until process dict is set), we use PB as usual.  New send_request and encode_request_message functions added to pass the encoding type to riak_pv_codec where the message is actually created (tsputreq or tsputreqttb depending on encoding)

3) Added process_response method to handle responses to the new message type

NB: I did modify rebar.config here to pick up the corresponding branch of riak_pb, because otherwise this won't build under basho_bench for Brian's benchmarking.  This should be removed when and if we merge this into end-to-end/timeseries
