### PR TITLE
READY: Perf/query ttb encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ ebin/*
 /.eqc-info
 /current_counterexample.eqc
 .local_dialyzer_plt
-
+test-unchanged.escript
 .idea
 *.iml

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "perf/query_ttb_encoding_lrb"}}}
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "riak_ts-develop"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "perf/query_ttb_encoding"}}}
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "riak_ts-develop-1.2"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "riak_ts-develop-1.2"}}}
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "perf/query_ttb_encoding"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "riak_ts-develop-1.2"}}}
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "perf/query_ttb_encoding_lrb"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "end-to-end/timeseries"}}}
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "riak_ts-develop-1.2"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1290,7 +1290,7 @@ replace_coverage(Pid, Bucket, Cover, Other) ->
                    Timeout}).
 
 use_native_encoding(Pid, Raw) when is_boolean(Raw) ->
-    erlang:put(pb_use_native_encoding, Raw),
+    erlang:put(Pid, [{pb_use_native_encoding, Raw}]),
     call_infinity(Pid, {use_native_encoding, Raw}).
 
 %% ====================================================================

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1437,7 +1437,7 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 %% @private
 decode(?TTB_MSG_CODE, MsgData) ->
-    riak_ttb_codec:decode(?TTB_MSG_CODE, MsgData);
+    riak_ttb_codec:decode(MsgData);
 decode(MsgCode, MsgData) ->
     riak_pb_codec:decode(MsgCode, MsgData).
 

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1985,6 +1985,11 @@ process_response(#request{msg = #tsqueryreq{}},
                  tsqueryresp, State) ->
     {reply, #tsqueryresp{}, State};
 
+process_response(#request{msg = #tsttbqueryreq{}},
+                 Result = #tsttbqueryresp{}, 
+		 State) ->
+    {reply, Result, State};
+
 process_response(#request{msg = #tsqueryreq{}},
                  Result = #tsqueryresp{},
                  State) ->

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1954,11 +1954,11 @@ process_response(#request{msg = #rpbgetbucketkeypreflistreq{}},
     {reply, {ok, Result}, State};
 
 process_response(#request{msg = #tsputreq{}},
-                 tsputresp, State) ->
+                 #tsputresp{}, State) ->
     {reply, ok, State};
 
 process_response(#request{msg = #tsttbputreq{}},
-                 tsputresp, State) ->
+                 tsttbputresp, State) ->
     {reply, ok, State};
 
 process_response(#request{msg = #tsdelreq{}},

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -35,6 +35,7 @@
 -include_lib("riak_pb/include/riak_yokozuna_pb.hrl").
 -include_lib("riak_pb/include/riak_dt_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
+-include_lib("riak_pb/include/riak_ts_ttb.hrl").
 -include("riakc.hrl").
 -behaviour(gen_server).
 

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1338,12 +1338,6 @@ handle_call({req, Msg, Timeout, Ctx}, From, State) when State#state.active =/= u
     {noreply, queue_request(new_request(Msg, From, Timeout, Ctx), State)};
 handle_call({req, Msg, Timeout}, From, State) ->
     {noreply, send_request(new_request(Msg, From, Timeout), State)};
-handle_call({req, true, Msg, Timeout}, From, State) ->
-    {noreply, send_request(true, new_request(Msg, From, Timeout), State)};
-handle_call({req, false, Msg, Timeout}, From, State) ->
-    {noreply, send_request(false, new_request(Msg, From, Timeout), State)};
-handle_call({req, undefined, Msg, Timeout}, From, State) ->
-    {noreply, send_request(undefined, new_request(Msg, From, Timeout), State)};
 handle_call({req, Msg, Timeout, Ctx}, From, State) ->
     {noreply, send_request(new_request(Msg, From, Timeout, Ctx), State)};
 handle_call(is_connected, _From, State) ->
@@ -2283,18 +2277,6 @@ send_request(Request0, State) when State#state.active =:= undefined ->
             maybe_enqueue_and_reconnect(Request, State#state{sock=undefined})
     end.
 
-send_request(UseNativeEncoding, Request0, State) when State#state.active =:= undefined ->
-    {Request, Pkt} = encode_request_message(UseNativeEncoding, Request0),
-    Transport = State#state.transport,
-    case Transport:send(State#state.sock, Pkt) of
-        ok ->
-            maybe_reply(after_send(Request, State#state{active = Request}));
-        {error, Reason} ->
-            error_logger:warning_msg("Socket error while sending riakc request: ~p.", [Reason]),
-            Transport:close(State#state.sock),
-            maybe_enqueue_and_reconnect(Request, State#state{sock=undefined})
-    end.
-
 %% Already encoded (for tunneled messages), but must provide Message Id
 %% for responding to the second form of send_request.
 encode_request_message(#request{msg={tunneled,MsgId,Pkt}}=Req) ->
@@ -2302,8 +2284,6 @@ encode_request_message(#request{msg={tunneled,MsgId,Pkt}}=Req) ->
 %% Unencoded Request (the normal PB client path)
 encode_request_message(#request{msg=Msg}=Req) ->
     {Req, riak_pb_codec:encode(Msg)}.
-encode_request_message(UseNativeEncoding, #request{msg=Msg}=Req) ->
-    {Req, riak_pb_codec:encode(UseNativeEncoding, Msg)}.
 
 %% If the socket was closed, see if we can enqueue the request and
 %% trigger a reconnect. Otherwise, return an error to the requestor.

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1981,7 +1981,7 @@ process_response(#request{msg = #tsqueryreq{}},
 
 process_response(#request{msg = #tsttbqueryreq{}},
                  Result = #tsttbqueryresp{}, 
-		 State) ->
+                 State) ->
     {reply, Result, State};
 
 process_response(#request{msg = #tsqueryreq{}},

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1291,8 +1291,7 @@ replace_coverage(Pid, Bucket, Cover, Other) ->
                    Timeout}).
 
 use_native_encoding(Pid, Raw) when is_boolean(Raw) ->
-    erlang:put(Pid, [{pb_use_native_encoding, Raw}]),
-    call_infinity(Pid, {use_native_encoding, Raw}).
+    erlang:put(Pid, [{pb_use_native_encoding, Raw}]).
 
 %% ====================================================================
 %% gen_server callbacks
@@ -1316,9 +1315,6 @@ init([Address, Port, Options]) ->
     end.
 
 %% @private
-handle_call({use_native_encoding, Raw}, From, State) when is_boolean(Raw) ->
-    {noreply, send_request(new_request(#rpbtoggleencodingreq{use_native=Raw}, From,
-                                        ?DEFAULT_PB_TIMEOUT), State)};
 handle_call({req, Msg, Timeout}, From, State) when State#state.sock =:= undefined ->
     case State#state.queue_if_disconnected of
         true ->
@@ -1649,9 +1645,6 @@ counter_val_options([_ | _Rest], _Req) ->
 -spec process_response(#request{}, rpb_resp(), #state{}) ->
                               {reply, term(), #state{}} |
                               {pending, #state{}}.
-process_response(#request{msg = #rpbtoggleencodingreq{}}, #rpbtoggleencodingresp{use_native=Raw}, State) ->
-    erlang:put(pb_use_native_encoding, Raw),
-    {reply, ok, State};
 process_response(#request{msg = rpbpingreq}, rpbpingresp, State) ->
     {reply, pong, State};
 process_response(#request{msg = rpbgetclientidreq},

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1290,6 +1290,7 @@ replace_coverage(Pid, Bucket, Cover, Other) ->
                    Timeout}).
 
 use_native_encoding(Pid, Raw) when is_boolean(Raw) ->
+    erlang:put(pb_use_native_encoding, Raw),
     call_infinity(Pid, {use_native_encoding, Raw}).
 
 %% ====================================================================
@@ -1337,6 +1338,12 @@ handle_call({req, Msg, Timeout, Ctx}, From, State) when State#state.active =/= u
     {noreply, queue_request(new_request(Msg, From, Timeout, Ctx), State)};
 handle_call({req, Msg, Timeout}, From, State) ->
     {noreply, send_request(new_request(Msg, From, Timeout), State)};
+handle_call({req, true, Msg, Timeout}, From, State) ->
+    {noreply, send_request(true, new_request(Msg, From, Timeout), State)};
+handle_call({req, false, Msg, Timeout}, From, State) ->
+    {noreply, send_request(false, new_request(Msg, From, Timeout), State)};
+handle_call({req, undefined, Msg, Timeout}, From, State) ->
+    {noreply, send_request(undefined, new_request(Msg, From, Timeout), State)};
 handle_call({req, Msg, Timeout, Ctx}, From, State) ->
     {noreply, send_request(new_request(Msg, From, Timeout, Ctx), State)};
 handle_call(is_connected, _From, State) ->
@@ -1956,6 +1963,10 @@ process_response(#request{msg = #tsputreq{}},
                  tsputresp, State) ->
     {reply, ok, State};
 
+process_response(#request{msg = #tsttbputreq{}},
+                 tsputresp, State) ->
+    {reply, ok, State};
+
 process_response(#request{msg = #tsdelreq{}},
                  tsdelresp, State) ->
     {reply, ok, State};
@@ -2272,6 +2283,18 @@ send_request(Request0, State) when State#state.active =:= undefined ->
             maybe_enqueue_and_reconnect(Request, State#state{sock=undefined})
     end.
 
+send_request(UseNativeEncoding, Request0, State) when State#state.active =:= undefined ->
+    {Request, Pkt} = encode_request_message(UseNativeEncoding, Request0),
+    Transport = State#state.transport,
+    case Transport:send(State#state.sock, Pkt) of
+        ok ->
+            maybe_reply(after_send(Request, State#state{active = Request}));
+        {error, Reason} ->
+            error_logger:warning_msg("Socket error while sending riakc request: ~p.", [Reason]),
+            Transport:close(State#state.sock),
+            maybe_enqueue_and_reconnect(Request, State#state{sock=undefined})
+    end.
+
 %% Already encoded (for tunneled messages), but must provide Message Id
 %% for responding to the second form of send_request.
 encode_request_message(#request{msg={tunneled,MsgId,Pkt}}=Req) ->
@@ -2279,6 +2302,8 @@ encode_request_message(#request{msg={tunneled,MsgId,Pkt}}=Req) ->
 %% Unencoded Request (the normal PB client path)
 encode_request_message(#request{msg=Msg}=Req) ->
     {Req, riak_pb_codec:encode(Msg)}.
+encode_request_message(UseNativeEncoding, #request{msg=Msg}=Req) ->
+    {Req, riak_pb_codec:encode(UseNativeEncoding, Msg)}.
 
 %% If the socket was closed, see if we can enqueue the request and
 %% trigger a reconnect. Otherwise, return an error to the requestor.

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -75,8 +75,7 @@
          tunnel/4,
          get_preflist/3, get_preflist/4,
          get_coverage/2, get_coverage/3,
-         replace_coverage/3, replace_coverage/4,
-         use_native_encoding/2]).
+         replace_coverage/3, replace_coverage/4]).
 
 %% Counter API
 -export([counter_incr/4, counter_val/3]).
@@ -1290,9 +1289,6 @@ replace_coverage(Pid, Bucket, Cover, Other) ->
                   {req, #rpbcoveragereq{type=T, bucket=B, replace_cover=Cover, unavailable_cover=Other},
                    Timeout}).
 
-use_native_encoding(Pid, Raw) when is_boolean(Raw) ->
-    erlang:put(Pid, [{pb_use_native_encoding, Raw}]).
-
 %% ====================================================================
 %% gen_server callbacks
 %% ====================================================================
@@ -1355,19 +1351,15 @@ handle_info({tcp_error, _Socket, Reason}, State) ->
     error_logger:error_msg("PBC client TCP error for ~p:~p - ~p\n",
                            [State#state.address, State#state.port, Reason]),
     disconnect(State);
-
 handle_info({tcp_closed, _Socket}, State) ->
     disconnect(State);
-
 handle_info({ssl_error, _Socket, Reason}, State) ->
     error_logger:error_msg("PBC client SSL error for ~p:~p - ~p\n",
                            [State#state.address, State#state.port, Reason]),
     disconnect(State);
-
 handle_info({ssl_closed, _Socket}, State) ->
     disconnect(State);
-
-%% Make sure the two Sock's match.  If a request timed out, but there was
+%% Make sure the two Socks match.  If a request timed out, but there was
 %% a response queued up behind it we do not want to process it.  Instead
 %% it should drop through and be ignored.
 handle_info({Proto, Sock, Data}, State=#state{sock = Sock, active = Active})
@@ -1378,7 +1370,7 @@ handle_info({Proto, Sock, Data}, State=#state{sock = Sock, active = Active})
             %% don't decode tunneled replies, we may not recognize the msgid
             {MsgCode, MsgData};
         _ ->
-            riak_pb_codec:decode(MsgCode, MsgData)
+            decode(MsgCode, MsgData)
     end,
     NewState = case Resp of
         #rpberrorresp{} ->
@@ -1442,6 +1434,12 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 %% ====================================================================
 %% internal functions
 %% ====================================================================
+
+%% @private
+decode(?TTB_MSG_CODE, MsgData) ->
+    riak_ttb_codec:decode(?TTB_MSG_CODE, MsgData);
+decode(MsgCode, MsgData) ->
+    riak_pb_codec:decode(MsgCode, MsgData).
 
 %% @private
 %% Parse options
@@ -1951,10 +1949,6 @@ process_response(#request{msg = #tsputreq{}},
                  #tsputresp{}, State) ->
     {reply, ok, State};
 
-process_response(#request{msg = #tsttbputreq{}},
-                 tsttbputresp, State) ->
-    {reply, ok, State};
-
 process_response(#request{msg = #tsdelreq{}},
                  tsdelresp, State) ->
     {reply, ok, State};
@@ -1978,11 +1972,6 @@ process_response(#request{msg = #tslistkeysreq{}} = Request,
 process_response(#request{msg = #tsqueryreq{}},
                  tsqueryresp, State) ->
     {reply, #tsqueryresp{}, State};
-
-process_response(#request{msg = #tsttbqueryreq{}},
-                 Result = #tsttbqueryresp{}, 
-                 State) ->
-    {reply, Result, State};
 
 process_response(#request{msg = #tsqueryreq{}},
                  Result = #tsqueryresp{},
@@ -2276,13 +2265,23 @@ send_request(Request0, State) when State#state.active =:= undefined ->
             maybe_enqueue_and_reconnect(Request, State#state{sock=undefined})
     end.
 
+%% @private
+encode(Msg=#tsputreq{}) ->
+    riak_ttb_codec:encode(Msg);
+encode(Msg=#tsgetreq{}) ->
+    riak_ttb_codec:encode(Msg);
+encode(Msg=#tsqueryreq{}) ->
+    riak_ttb_codec:encode(Msg);
+encode(Msg) ->
+    riak_pb_codec:encode(Msg).
+
 %% Already encoded (for tunneled messages), but must provide Message Id
 %% for responding to the second form of send_request.
 encode_request_message(#request{msg={tunneled,MsgId,Pkt}}=Req) ->
     {Req#request{msg={tunneled,MsgId}},[MsgId|Pkt]};
 %% Unencoded Request (the normal PB client path)
 encode_request_message(#request{msg=Msg}=Req) ->
-    {Req, riak_pb_codec:encode(Msg)}.
+    {Req, encode(Msg)}.
 
 %% If the socket was closed, see if we can enqueue the request and
 %% trigger a reconnect. Otherwise, return an error to the requestor.

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -74,9 +74,6 @@ query(Pid, QueryText, Interpolations) ->
 %%      first element, and a list of records, each represented as a
 %%      list of values, in the second element, or an @{error, Reason@}
 %%      tuple.
-%%
-%%      query/5 acts like query/4 with interpolations and coverage
-%%      list, but additionally specifies the encoding
 
 query(Pid, QueryText, Interpolations, Cover) ->
     Message = riakc_ts_query_operator:serialize(QueryText, Interpolations),

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -34,6 +34,7 @@
 -include_lib("riak_pb/include/riak_pb.hrl").
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
+-include_lib("riak_pb/include/riak_ts_ttb.hrl").
 -include("riakc.hrl").
 
 -type table_name() :: binary().

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -86,11 +86,11 @@ query(Pid, QueryText) ->
 %%
 
 query(Pid, QueryText, true) ->
-	query(Pid, QueryText, [], true);
+        query(Pid, QueryText, [], true);
 query(Pid, QueryText, false) ->
-	query(Pid, QueryText, [], false);
+        query(Pid, QueryText, [], false);
 query(Pid, QueryText, Interpolations) ->
-	query(Pid, QueryText, Interpolations, use_native_encoding(Pid)).
+        query(Pid, QueryText, Interpolations, use_native_encoding(Pid)).
 
 -spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}], term()) ->
                    {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
@@ -112,11 +112,11 @@ query(Pid, QueryText, Interpolations) ->
 %%
 
 query(Pid, QueryText, Interpolations, true) ->
-	get_query_response_nocover(Pid, QueryText, Interpolations, true);
+        get_query_response_nocover(Pid, QueryText, Interpolations, true);
 query(Pid, QueryText, Interpolations, false) ->
-	get_query_response_nocover(Pid, QueryText, Interpolations, false);
+        get_query_response_nocover(Pid, QueryText, Interpolations, false);
 query(Pid, QueryText, Interpolations, Cover) ->
-	query(Pid, QueryText, Interpolations, Cover, use_native_encoding(Pid)).
+        query(Pid, QueryText, Interpolations, Cover, use_native_encoding(Pid)).
 
 get_query_response_nocover(Pid, QueryText, Interpolations, UseNativeEncoding) ->
     Message = riakc_ts_query_operator:serialize(UseNativeEncoding, QueryText, Interpolations),

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -24,9 +24,9 @@
 
 -module(riakc_ts).
 
--export([query/2, query/3, query/4,
+-export([query/2, query/3, query/4, query/5,
          get_coverage/3,
-         put/3, put/4,
+         put/3, put/4, put/5,
          get/4,
          delete/4,
          stream_list_keys/3]).
@@ -41,9 +41,12 @@
 -type ts_value() :: riak_pb_ts_codec:ldbvalue().
 -type ts_columnname() :: riak_pb_ts_codec:tscolumnname().
 
+%% Determine encoding type from Pid proplist stored in process dictionary
 
 use_native_encoding(Pid) ->
     use_native_encoding_from_proplist(get(Pid)).
+
+%% Extract the encoding type from a proplist
 
 use_native_encoding_from_proplist(undefined) ->
     false;
@@ -57,36 +60,88 @@ use_native_encoding_from_proplist(Proplist) ->
 %%      first element, and a list of records, each represented as a
 %%      list of values, in the second element, or an @{error, Reason@}
 %%      tuple.
+%%
+%%      query/2 always uses the default encoding for communication
+%%      with the server (set by riak_pb_socket:use_native_encoding/2)
+
 query(Pid, QueryText) ->
     query(Pid, QueryText, []).
 
--spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}]) ->
+-spec query(Pid::pid(), Query::string(), [{binary(), binary()}] | boolean()) ->
                    {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
-%% @doc Execute a "SELECT ..." Query with client Pid, using
-%%      Interpolations.  The result returned is a tuple containing a
-%%      list of columns as binaries in the first element, and a list
-%%      of records, each represented as a list of values, in the
-%%      second element, or an @{error, Reason@} tuple.
+%% @doc Execute a "SELECT ..." Query with client.  The result returned
+%%      is a tuple containing a list of columns as binaries in the
+%%      first element, and a list of records, each represented as a
+%%      list of values, in the second element, or an @{error, Reason@}
+%%      tuple.
+%%
+%%      query/3 switches on the last argument:
+%%
+%%        When a list of interpolations is specified, a query using
+%%        interpolations is sent to the server using the default
+%%        encoding (set by riak_pb_socket:use_native_encoding/2)
+%%   
+%%        When a boolean is specified, query/3 acts just like query/2
+%%        but uses the boolean to determine the encoding type
+%%
+
+query(Pid, QueryText, true) ->
+	query(Pid, QueryText, [], true);
+query(Pid, QueryText, false) ->
+	query(Pid, QueryText, [], false);
 query(Pid, QueryText, Interpolations) ->
-    Message = riakc_ts_query_operator:serialize(use_native_encoding(Pid), QueryText, Interpolations),
+	query(Pid, QueryText, Interpolations, use_native_encoding(Pid)).
+
+-spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}], term()) ->
+                   {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
+%% @doc Execute a "SELECT ..." Query with client.  The result returned
+%%      is a tuple containing a list of columns as binaries in the
+%%      first element, and a list of records, each represented as a
+%%      list of values, in the second element, or an @{error, Reason@}
+%%      tuple.
+%%
+%%      query/4 switches in the last argument:
+%%
+%%        When these are: (interpolations, cover), a query using an
+%%        explicit coverage list is sent to the server, using the
+%%        default encoding (set by riak_pb_socket:use_native_encoding/2)
+%%   
+%%        When these are: (interpolations, boolean), query/4 acts just
+%%        like query/3 but uses the boolean to determine the encoding
+%%        type
+%%
+
+query(Pid, QueryText, Interpolations, true) ->
+	get_query_response_nocover(Pid, QueryText, Interpolations, true);
+query(Pid, QueryText, Interpolations, false) ->
+	get_query_response_nocover(Pid, QueryText, Interpolations, false);
+query(Pid, QueryText, Interpolations, Cover) ->
+	query(Pid, QueryText, Interpolations, Cover, use_native_encoding(Pid)).
+
+get_query_response_nocover(Pid, QueryText, Interpolations, UseNativeEncoding) ->
+    Message = riakc_ts_query_operator:serialize(UseNativeEncoding, QueryText, Interpolations),
     Response = server_call(Pid, Message),
     riakc_ts_query_operator:deserialize(Response).
 
-query(Pid, QueryText, Interpolations, Cover) ->
-    UseNativeEncoding = use_native_encoding(Pid),
-    Message = riakc_ts_query_operator:serialize(UseNativeEncoding, QueryText, Interpolations),
-    Response = get_query_response(UseNativeEncoding, Pid, Message, Cover),
+-spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}], Cover::term(), UseNativeEncoding::boolean()) ->
+                   {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
+%% @doc Execute a "SELECT ..." Query with client.  The result returned
+%%      is a tuple containing a list of columns as binaries in the
+%%      first element, and a list of records, each represented as a
+%%      list of values, in the second element, or an @{error, Reason@}
+%%      tuple.
+%%
+%%      query/5 acts like query/4 with interpolations and coverage
+%%      list, but additionally specifies the encoding
+
+query(Pid, QueryText, Interpolations, Cover, false) ->
+    Message = riakc_ts_query_operator:serialize(false, QueryText, Interpolations),
+    Response = server_call(Pid, Message#tsqueryreq{cover_context=Cover}),
+    riakc_ts_query_operator:deserialize(Response);
+query(Pid, QueryText, Interpolations, Cover, true) ->
+    Message = riakc_ts_query_operator:serialize(true, QueryText, Interpolations),
+    Response = server_call(Pid, Message#tsttbqueryreq{cover_context=Cover}),
     riakc_ts_query_operator:deserialize(Response).
-
-%% ------------------------------------------------------------
-%% Construct an appropriate request depending on encoding, and return
-%% the response
-%% ------------------------------------------------------------
-
-get_query_response(false, Pid, Message, Cover) ->
-    server_call(Pid, Message#tsqueryreq{cover_context=Cover});
-get_query_response(true, Pid, Message, Cover) ->
-    server_call(Pid, Message#tsttbqueryreq{cover_context=Cover}).
 
 %% @doc Generate a parallel coverage plan for the specified query
 get_coverage(Pid, Table, QueryText) ->
@@ -105,15 +160,13 @@ get_coverage(Pid, Table, QueryText) ->
 %%      DDL.  On success, 'ok' is returned, else an @{error, Reason@}
 %%      tuple.
 %%
-%%      Note: Type validation is done on the first record only.  If
-%%      any subsequent record contains fewer or more elements than
-%%      there are columns, or some element fails to convert to the
-%%      appropriate type, the rest of the records will not get
-%%      inserted.
+%%      put/3 uses the default encoding for communication with the
+%%      server (set by riak_pb_socket:use_native_encoding/2)
+
 put(Pid, TableName, Measurements) ->
     put(Pid, TableName, [], Measurements).
 
--spec put(Pid::pid(), Table::table_name(), ColumnNames::[ts_columnname()], Data::[[ts_value()]]) ->
+-spec put(Pid::pid(), Table::table_name(), [ts_columnname()] | [[ts_value()]], [[ts_value()]] | boolean()) ->
                  ok | {error, Reason::term()}.
 %% @doc Make data records from Data and insert them, individually,
 %%      into a time-series Table, using client Pid. Each record is a
@@ -124,8 +177,40 @@ put(Pid, TableName, Measurements) ->
 %%
 %%      As of 2015-11-05, ColumnNames parameter is ignored, the function
 %%      expects the full set of fields in each element of Data.
+%%
+%%      put/4 switches on the last two arguments: 
+%%
+%%         When these are: (column names, measurement set), put/4 uses
+%%         the default encoding (set by
+%%         riak_pb_socket:use_native_encoding/2)
+%%
+%%         When these are: (measurement set, boolean), put/4 acts just
+%%         like put/3, but with encoding explicitly specified
+
+put(Pid, TableName, Measurements, true) ->
+    put(Pid, TableName, [], Measurements, true);
+put(Pid, TableName, Measurements, false) ->
+    put(Pid, TableName, [], Measurements, false);
 put(Pid, TableName, ColumnNames, Measurements) ->
-    Message = riakc_ts_put_operator:serialize(use_native_encoding(Pid), TableName, ColumnNames, Measurements),
+    put(Pid, TableName, ColumnNames, Measurements, use_native_encoding(Pid)).
+
+-spec put(Pid::pid(), Table::table_name(), ColumnNames::[ts_columnname()], Data::[[ts_value()]], UseNativeEncoding::boolean()) ->
+                 ok | {error, Reason::term()}.
+%% @doc Make data records from Data and insert them, individually,
+%%      into a time-series Table, using client Pid. Each record is a
+%%      list of values of appropriate types for the complete set of
+%%      table column names, in the order in which they appear in table's
+%%      DDL.  On success, 'ok' is returned, else an @{error, Reason@}
+%%      tuple.  
+%%
+%%      As of 2015-11-05, ColumnNames parameter is ignored, the function
+%%      expects the full set of fields in each element of Data.
+%%
+%%      put/5 acts just like put/4 with column names and measurement
+%%      set specified, but with the encoding explicitly specified
+
+put(Pid, TableName, ColumnNames, Measurements, UseNativeEncoding) ->
+    Message = riakc_ts_put_operator:serialize(UseNativeEncoding, TableName, ColumnNames, Measurements),
     Response = server_call(Pid, Message),
     riakc_ts_put_operator:deserialize(Response).
 

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -106,10 +106,10 @@ put(Pid, TableName, Measurements) ->
 %%      As of 2015-11-05, ColumnNames parameter is ignored, the function
 %%      expects the full set of fields in each element of Data.
 put(Pid, TableName, ColumnNames, Measurements) ->
-    Message = riakc_ts_put_operator:serialize(TableName, ColumnNames, Measurements),
-    Response = server_call(Pid, Message),
+    UseNativeEncoding = get(pb_use_native_encoding),
+    Message = riakc_ts_put_operator:serialize(UseNativeEncoding, TableName, ColumnNames, Measurements),
+    Response = server_call(UseNativeEncoding, Pid, Message),
     riakc_ts_put_operator:deserialize(Response).
-
 
 -spec delete(Pid::pid(), Table::table_name(), Key::[ts_value()],
              Options::proplists:proplist()) ->
@@ -182,4 +182,9 @@ stream_list_keys(Pid, Table, Options) ->
 server_call(Pid, Message) ->
     gen_server:call(Pid,
                     {req, Message, riakc_pb_socket:default_timeout(timeseries)},
+                    infinity).
+
+server_call(UseNativeEncoding, Pid, Message) ->
+    gen_server:call(Pid,
+                    {req, UseNativeEncoding, Message, riakc_pb_socket:default_timeout(timeseries)},
                     infinity).

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -27,10 +27,21 @@
 -include_lib("riak_pb/include/riak_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 
--export([serialize/3,
+-export([serialize/4,
          deserialize/1]).
 
-serialize(TableName, ColumnNames, Measurements) ->
+%% serialize uses the process dictionary to check if native encoding
+%% should be used.  If true (ttb encoding) call encode_rows_for_ttb.
+%% If false, call default pb encoding function.
+
+serialize(true, TableName, ColumnNames, Measurements) ->
+    ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
+    SerializedRows = riak_pb_ts_codec:encode_rows_for_ttb(Measurements),
+    #tsttbputreq{table   = TableName,
+                 columns = ColumnDescs,
+		 rows    = SerializedRows};
+
+serialize(_, TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
     SerializedRows = riak_pb_ts_codec:encode_rows_non_strict(Measurements),
     #tsputreq{table   = TableName,

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -30,9 +30,12 @@
 -export([serialize/4,
          deserialize/1]).
 
-%% serialize uses the process dictionary to check if native encoding
-%% should be used.  If true (ttb encoding) call encode_rows_for_ttb.
+%% ------------------------------------------------------------
+%% Serialize into tsttbputreq or tsputreq depending on encoding
+%%
+%% If first arg is true (ttb encoding) call encode_rows_for_ttb.
 %% If false, call default pb encoding function.
+%% ------------------------------------------------------------
 
 serialize(true, TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -28,26 +28,12 @@
 -include_lib("riak_pb/include/riak_ts_ttb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 
--export([serialize/4,
+-export([serialize/3,
          deserialize/1]).
 
-%% ------------------------------------------------------------
-%% Serialize into tsttbputreq or tsputreq depending on encoding
-%%
-%% If first arg is true (ttb encoding) call encode_rows_for_ttb.
-%% If false, call default pb encoding function.
-%% ------------------------------------------------------------
-
-serialize(true, TableName, ColumnNames, Measurements) ->
+serialize(TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
-    SerializedRows = riak_pb_ts_codec:encode_rows_for_ttb(Measurements),
-    #tsttbputreq{table   = TableName,
-                 columns = ColumnDescs,
-                 rows    = SerializedRows};
-
-serialize(_, TableName, ColumnNames, Measurements) ->
-    ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
-    SerializedRows = riak_pb_ts_codec:encode_rows_non_strict(Measurements),
+    SerializedRows = riak_ttb_codec:encode_ts_rows(Measurements),
     #tsputreq{table   = TableName,
               columns = ColumnDescs,
               rows    = SerializedRows}.

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -25,6 +25,7 @@
 -module(riakc_ts_put_operator).
 
 -include_lib("riak_pb/include/riak_pb.hrl").
+-include_lib("riak_pb/include/riak_ts_ttb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 
 -export([serialize/4,

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -43,7 +43,7 @@ serialize(true, TableName, ColumnNames, Measurements) ->
     SerializedRows = riak_pb_ts_codec:encode_rows_for_ttb(Measurements),
     #tsttbputreq{table   = TableName,
                  columns = ColumnDescs,
-		 rows    = SerializedRows};
+                 rows    = SerializedRows};
 
 serialize(_, TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -28,21 +28,11 @@
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_ttb.hrl").
 
--export([serialize/3,
+-export([serialize/2,
          deserialize/1]).
 
 
-%------------------------------------------------------------
-% Serialize into tsqueryreq or tsttbqueryreq depending on encoding
-%------------------------------------------------------------
-
-serialize(true, QueryText, Interpolations) ->
-    Content = #tsinterpolation{
-                 base = QueryText,
-                 interpolations = serialize_interpolations(Interpolations)},
-    #tsttbqueryreq{query = Content};
-
-serialize(_, QueryText, Interpolations) ->
+serialize(QueryText, Interpolations) ->
     Content = #tsinterpolation{
                  base = QueryText,
                  interpolations = serialize_interpolations(Interpolations)},
@@ -60,9 +50,5 @@ serialize_interpolations([{Key, Value} | RemainingInterps],
 
 deserialize({error, Message}) -> {error, Message};
 
-deserialize(#tsqueryresp{columns = Columns_, rows = Rows_}) ->
-    Columns = [C || #tscolumndescription{name = C} <- Columns_],
-    Rows = riak_pb_ts_codec:decode_rows(Rows_),
-    {Columns, Rows};
-deserialize(#tsttbqueryresp{columns = {ColumnNames, _ColumnTypes}, rows = Rows}) ->
+deserialize(#tsqueryresp{columns = {ColumnNames, _ColumnTypes}, rows = Rows}) ->
     {ColumnNames, Rows}.

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -27,10 +27,21 @@
 -include_lib("riak_pb/include/riak_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 
--export([serialize/2,
+-export([serialize/3,
          deserialize/1]).
 
-serialize(QueryText, Interpolations) ->
+
+%------------------------------------------------------------
+% Serialize into tsqueryreq or tsttbqueryreq depending on encoding
+%------------------------------------------------------------
+
+serialize(true, QueryText, Interpolations) ->
+    Content = #tsinterpolation{
+                 base = QueryText,
+                 interpolations = serialize_interpolations(Interpolations)},
+    #tsttbqueryreq{query = Content};
+
+serialize(_, QueryText, Interpolations) ->
     Content = #tsinterpolation{
                  base = QueryText,
                  interpolations = serialize_interpolations(Interpolations)},

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -26,6 +26,7 @@
 
 -include_lib("riak_pb/include/riak_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
+-include_lib("riak_pb/include/riak_ts_ttb.hrl").
 
 -export([serialize/3,
          deserialize/1]).

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -62,4 +62,6 @@ deserialize({error, Message}) -> {error, Message};
 deserialize(#tsqueryresp{columns = Columns_, rows = Rows_}) ->
     Columns = [C || #tscolumndescription{name = C} <- Columns_],
     Rows = riak_pb_ts_codec:decode_rows(Rows_),
-    {Columns, Rows}.
+    {Columns, Rows};
+deserialize(#tsttbqueryresp{columns = {ColumnNames, _ColumnTypes}, rows = Rows}) ->
+    {ColumnNames, Rows}.


### PR DESCRIPTION
<hr>
**Context**

This is part of a set of related PRs to rework handling of PB vs TTB encoding for client/server messages:
* https://github.com/basho/riak-erlang-client/pull/267 
* https://github.com/basho/riak_pb/pull/182
* https://github.com/basho/riak_api/pull/109
* https://github.com/basho/riak_kv/pull/1378

The original addition of alternate encodings was a hybrid implementation which 1) required the client and server to agree via a handshaking protocol about what encoding would be used, 2) used messages for both encodings that were generated from the .proto files, but some were only used for TTB encoding, and 3) allowed the server to send PB-encoded responses to TTB-encoded requests.

This work is an attempt to rationalize this situation, and to simplify how differently-encoded messages are handled within riak.  The guiding principles are:

1. Even as we optimize encodings for RiakTS performance, the server should continue to support PB-encoding as before.  We do _not_, for example,  want to break custom PB connections made outside our supported client codebase

2. We should be able to optimize messages for whatever encoding is imposed on them.  

3. The server should handle interleaved messages with different encodings seamlessly, without any handshaking about encoding type

4. We should guarantee that responses are encoded in the same way as the requests that generated them

<hr>
**Notes**

* Regarding point 2. above, although we currently pack data into the same containers differently for PB vs TTB encoding, we do not currently have a use-case that requires separate message _structures_, so the decision was made to keep the existing .proto-generated messages until we have such a use-case.

* Because TTB encoding is self-describing, we do not need to switch on per-message 8-bit MsgCode, as with PB-encoded messages, to know how to decode them.  This work therefor adds a single new MsgCode (104) to indicate that a message is TTB-encoded.   This allows the server to determine what encoding is being used per-message and without handshaking, addressing point 3. above.  It also preserves the remaining 8-bit space for future messages if needed.

* The server now implements separate services for PB and TTB-encoded messages, selected on MsgCode.  Because the processing is done per-service, and not per-message, this also guarantees that responses are encoded in the same way as the requests, addressing point 4 above.  This is important, for example, for tsquery requests, where it is the encoding of the _responses_, not the _requests_ that matters for performance.

<hr>
**Changes in this repo:**

* **src/riakc_pb_socket.erl** 

  * riak_pb/include/riak_ts_ttb.hrl included to define the new TTB MsgCode, 104.

  * old handle_call, encode_request, send_request calls that switched on encoding type stored in a process dictionary have been removed

  * process_response handler for now-obsolete toggle encoding message has been removed

  * ts put and query operators have been hardwired to send TTB-encoded messages.  Note that this does not prevent other clients from sending these requests as PB-encoded messages, but it optimizes performance for this client.

  * The API call for specifying an encoding type has been removed altogether.  Note that this incidentally fixes the bug noted in https://bashoeng.atlassian.net/browse/CLIENTS-794 (#266), that a single value for the encoding type was stored process-wide for all Pids.

* **src/riakc_ts_put_operator.erl, src/riakc_ts_query_operator.erl** 
 * Updated to correctly handle TTB versions of put and query messages