### PR TITLE
READY: TS Put / Query use TTB encoding.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ ebin/*
 /.eqc-info
 /current_counterexample.eqc
 .local_dialyzer_plt
-
+test-unchanged.escript
 .idea
 *.iml

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {eunit_opts, [verbose]}.
 {erl_opts, [warnings_as_errors, debug_info, nowarn_deprecated_type]}.
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "riak_ts-develop-1.2"}}}
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "perf/query_ttb_encoding_lrb"}}}
        ]}.
 {edoc_opts, [{stylesheet_file, "priv/edoc.css"},
              {preprocess, true}]}.

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -2268,6 +2268,8 @@ send_request(Request0, State) when State#state.active =:= undefined ->
 %% @private
 encode(Msg=#tsputreq{}) ->
     riak_ttb_codec:encode(Msg);
+encode(Msg=#tsgetreq{}) ->
+    riak_ttb_codec:encode(Msg);
 encode(Msg=#tsqueryreq{}) ->
     riak_ttb_codec:encode(Msg);
 encode(Msg) ->

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -157,7 +157,7 @@ delete(Pid, TableName, Key, Options)
 %%      returns @{error, @{ErrCode, ErrMsg@}@}.
 get(Pid, TableName, Key, Options) ->
     Message = #tsgetreq{table   = TableName,
-                        key     = riak_pb_ts_codec:encode_cells_non_strict(Key),
+                        key     = Key,
                         timeout = proplists:get_value(timeout, Options)},
 
     case server_call(Pid, Message) of
@@ -166,8 +166,8 @@ get(Pid, TableName, Key, Options) ->
         {error, OtherError} ->
             {error, OtherError};
         Response ->
-            Columns = [C || #tscolumndescription{name = C} <- Response#tsgetresp.columns],
-            Rows = [tuple_to_list(X) || X <- riak_pb_ts_codec:decode_rows(Response#tsgetresp.rows)],
+            Columns = Response#tsgetresp.columns,
+            Rows = Response#tsgetresp.rows,
             {ok, {Columns, Rows}}
     end.
 

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -24,9 +24,9 @@
 
 -module(riakc_ts).
 
--export([query/2, query/3, query/4, query/5,
+-export([query/2, query/3, query/4,
          get_coverage/3,
-         put/3, put/4, put/5,
+         put/3, put/4,
          get/4,
          delete/4,
          stream_list_keys/3]).
@@ -41,18 +41,6 @@
 -type ts_value() :: riak_pb_ts_codec:ldbvalue().
 -type ts_columnname() :: riak_pb_ts_codec:tscolumnname().
 
-%% Determine encoding type from Pid proplist stored in process dictionary
-
-use_native_encoding(Pid) ->
-    use_native_encoding_from_proplist(get(Pid)).
-
-%% Extract the encoding type from a proplist
-
-use_native_encoding_from_proplist(undefined) ->
-    false;
-use_native_encoding_from_proplist(Proplist) ->
-    proplists:get_bool(pb_use_native_encoding, Proplist).
-
 -spec query(Pid::pid(), Query::string()) ->
                    {ColumnNames::[ts_columnname()], Rows::[tuple()]} | {error, Reason::term()}.
 %% @doc Execute a "SELECT ..." Query with client.  The result returned
@@ -61,13 +49,11 @@ use_native_encoding_from_proplist(Proplist) ->
 %%      list of values, in the second element, or an @{error, Reason@}
 %%      tuple.
 %%
-%%      query/2 always uses the default encoding for communication
-%%      with the server (set by riak_pb_socket:use_native_encoding/2)
 
 query(Pid, QueryText) ->
     query(Pid, QueryText, []).
 
--spec query(Pid::pid(), Query::string(), [{binary(), binary()}] | boolean()) ->
+-spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}]) ->
                    {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
 %% @doc Execute a "SELECT ..." Query with client.  The result returned
 %%      is a tuple containing a list of columns as binaries in the
@@ -75,55 +61,13 @@ query(Pid, QueryText) ->
 %%      list of values, in the second element, or an @{error, Reason@}
 %%      tuple.
 %%
-%%      query/3 switches on the last argument:
-%%
-%%        When a list of interpolations is specified, a query using
-%%        interpolations is sent to the server using the default
-%%        encoding (set by riak_pb_socket:use_native_encoding/2)
-%%   
-%%        When a boolean is specified, query/3 acts just like query/2
-%%        but uses the boolean to determine the encoding type
-%%
 
-query(Pid, QueryText, true) ->
-        query(Pid, QueryText, [], true);
-query(Pid, QueryText, false) ->
-        query(Pid, QueryText, [], false);
 query(Pid, QueryText, Interpolations) ->
-        query(Pid, QueryText, Interpolations, use_native_encoding(Pid)).
-
--spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}], term()) ->
-                   {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
-%% @doc Execute a "SELECT ..." Query with client.  The result returned
-%%      is a tuple containing a list of columns as binaries in the
-%%      first element, and a list of records, each represented as a
-%%      list of values, in the second element, or an @{error, Reason@}
-%%      tuple.
-%%
-%%      query/4 switches in the last argument:
-%%
-%%        When these are: (interpolations, cover), a query using an
-%%        explicit coverage list is sent to the server, using the
-%%        default encoding (set by riak_pb_socket:use_native_encoding/2)
-%%   
-%%        When these are: (interpolations, boolean), query/4 acts just
-%%        like query/3 but uses the boolean to determine the encoding
-%%        type
-%%
-
-query(Pid, QueryText, Interpolations, true) ->
-        get_query_response_nocover(Pid, QueryText, Interpolations, true);
-query(Pid, QueryText, Interpolations, false) ->
-        get_query_response_nocover(Pid, QueryText, Interpolations, false);
-query(Pid, QueryText, Interpolations, Cover) ->
-        query(Pid, QueryText, Interpolations, Cover, use_native_encoding(Pid)).
-
-get_query_response_nocover(Pid, QueryText, Interpolations, UseNativeEncoding) ->
-    Message = riakc_ts_query_operator:serialize(UseNativeEncoding, QueryText, Interpolations),
+    Message = riakc_ts_query_operator:serialize(QueryText, Interpolations),
     Response = server_call(Pid, Message),
     riakc_ts_query_operator:deserialize(Response).
 
--spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}], Cover::term(), UseNativeEncoding::boolean()) ->
+-spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}], Cover::term()) ->
                    {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
 %% @doc Execute a "SELECT ..." Query with client.  The result returned
 %%      is a tuple containing a list of columns as binaries in the
@@ -134,13 +78,9 @@ get_query_response_nocover(Pid, QueryText, Interpolations, UseNativeEncoding) ->
 %%      query/5 acts like query/4 with interpolations and coverage
 %%      list, but additionally specifies the encoding
 
-query(Pid, QueryText, Interpolations, Cover, false) ->
-    Message = riakc_ts_query_operator:serialize(false, QueryText, Interpolations),
+query(Pid, QueryText, Interpolations, Cover) ->
+    Message = riakc_ts_query_operator:serialize(QueryText, Interpolations),
     Response = server_call(Pid, Message#tsqueryreq{cover_context=Cover}),
-    riakc_ts_query_operator:deserialize(Response);
-query(Pid, QueryText, Interpolations, Cover, true) ->
-    Message = riakc_ts_query_operator:serialize(true, QueryText, Interpolations),
-    Response = server_call(Pid, Message#tsttbqueryreq{cover_context=Cover}),
     riakc_ts_query_operator:deserialize(Response).
 
 %% @doc Generate a parallel coverage plan for the specified query
@@ -150,23 +90,7 @@ get_coverage(Pid, Table, QueryText) ->
                                replace_cover=undefined,
                                table = Table}).
 
-
--spec put(Pid::pid(), Table::table_name(), Data::[[ts_value()]]) ->
-                 ok | {error, Reason::term()}.
-%% @doc Make data records from Data and insert them, individually,
-%%      into a time-series Table, using client Pid. Each record is a
-%%      list of values of appropriate types for the complete set of
-%%      table columns, in the order in which they appear in table's
-%%      DDL.  On success, 'ok' is returned, else an @{error, Reason@}
-%%      tuple.
-%%
-%%      put/3 uses the default encoding for communication with the
-%%      server (set by riak_pb_socket:use_native_encoding/2)
-
-put(Pid, TableName, Measurements) ->
-    put(Pid, TableName, [], Measurements).
-
--spec put(Pid::pid(), Table::table_name(), [ts_columnname()] | [[ts_value()]], [[ts_value()]] | boolean()) ->
+-spec put(Pid::pid(), Table::table_name(), [[ts_value()]]) ->
                  ok | {error, Reason::term()}.
 %% @doc Make data records from Data and insert them, individually,
 %%      into a time-series Table, using client Pid. Each record is a
@@ -178,23 +102,11 @@ put(Pid, TableName, Measurements) ->
 %%      As of 2015-11-05, ColumnNames parameter is ignored, the function
 %%      expects the full set of fields in each element of Data.
 %%
-%%      put/4 switches on the last two arguments: 
-%%
-%%         When these are: (column names, measurement set), put/4 uses
-%%         the default encoding (set by
-%%         riak_pb_socket:use_native_encoding/2)
-%%
-%%         When these are: (measurement set, boolean), put/4 acts just
-%%         like put/3, but with encoding explicitly specified
 
-put(Pid, TableName, Measurements, true) ->
-    put(Pid, TableName, [], Measurements, true);
-put(Pid, TableName, Measurements, false) ->
-    put(Pid, TableName, [], Measurements, false);
-put(Pid, TableName, ColumnNames, Measurements) ->
-    put(Pid, TableName, ColumnNames, Measurements, use_native_encoding(Pid)).
+put(Pid, TableName, Measurements) ->
+    put(Pid, TableName, [], Measurements).
 
--spec put(Pid::pid(), Table::table_name(), ColumnNames::[ts_columnname()], Data::[[ts_value()]], UseNativeEncoding::boolean()) ->
+-spec put(Pid::pid(), Table::table_name(), ColumnNames::[ts_columnname()], Data::[[ts_value()]]) ->
                  ok | {error, Reason::term()}.
 %% @doc Make data records from Data and insert them, individually,
 %%      into a time-series Table, using client Pid. Each record is a
@@ -206,11 +118,9 @@ put(Pid, TableName, ColumnNames, Measurements) ->
 %%      As of 2015-11-05, ColumnNames parameter is ignored, the function
 %%      expects the full set of fields in each element of Data.
 %%
-%%      put/5 acts just like put/4 with column names and measurement
-%%      set specified, but with the encoding explicitly specified
 
-put(Pid, TableName, ColumnNames, Measurements, UseNativeEncoding) ->
-    Message = riakc_ts_put_operator:serialize(UseNativeEncoding, TableName, ColumnNames, Measurements),
+put(Pid, TableName, ColumnNames, Measurements) ->
+    Message = riakc_ts_put_operator:serialize(TableName, ColumnNames, Measurements),
     Response = server_call(Pid, Message),
     riakc_ts_put_operator:deserialize(Response).
 

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -28,26 +28,12 @@
 -include_lib("riak_pb/include/riak_ts_ttb.hrl").
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 
--export([serialize/4,
+-export([serialize/3,
          deserialize/1]).
 
-%% ------------------------------------------------------------
-%% Serialize into tsttbputreq or tsputreq depending on encoding
-%%
-%% If first arg is true (ttb encoding) call encode_rows_for_ttb.
-%% If false, call default pb encoding function.
-%% ------------------------------------------------------------
-
-serialize(true, TableName, ColumnNames, Measurements) ->
+serialize(TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
-    SerializedRows = riak_pb_ts_codec:encode_rows_for_ttb(Measurements),
-    #tsttbputreq{table   = TableName,
-                 columns = ColumnDescs,
-                 rows    = SerializedRows};
-
-serialize(_, TableName, ColumnNames, Measurements) ->
-    ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
-    SerializedRows = riak_pb_ts_codec:encode_rows_non_strict(Measurements),
+    SerializedRows = riak_ttb_codec:encode_ts_rows(Measurements),
     #tsputreq{table   = TableName,
               columns = ColumnDescs,
               rows    = SerializedRows}.

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -28,21 +28,11 @@
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_ttb.hrl").
 
--export([serialize/3,
+-export([serialize/2,
          deserialize/1]).
 
 
-%------------------------------------------------------------
-% Serialize into tsqueryreq or tsttbqueryreq depending on encoding
-%------------------------------------------------------------
-
-serialize(true, QueryText, Interpolations) ->
-    Content = #tsinterpolation{
-                 base = QueryText,
-                 interpolations = serialize_interpolations(Interpolations)},
-    #tsttbqueryreq{query = Content};
-
-serialize(_, QueryText, Interpolations) ->
+serialize(QueryText, Interpolations) ->
     Content = #tsinterpolation{
                  base = QueryText,
                  interpolations = serialize_interpolations(Interpolations)},
@@ -60,9 +50,5 @@ serialize_interpolations([{Key, Value} | RemainingInterps],
 
 deserialize({error, Message}) -> {error, Message};
 
-deserialize(#tsqueryresp{columns = Columns_, rows = Rows_}) ->
-    Columns = [C || #tscolumndescription{name = C} <- Columns_],
-    Rows = riak_pb_ts_codec:decode_rows(Rows_),
-    {Columns, Rows};
-deserialize(#tsttbqueryresp{columns = {ColumnNames, _ColumnTypes}, rows = Rows}) ->
+deserialize(#tsqueryresp{columns = {ColumnNames, _ColumnTypes}, rows = Rows}) ->
     {ColumnNames, Rows}.


### PR DESCRIPTION
Ensure tsputreq and tsqueryreq are encoded / decoded as TTB. Remove switching to / from native encoding.