### PR TITLE
sanitize args for riakc_ts functions, allow strings for Table

### DIFF
--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -63,7 +63,8 @@ query(Pid, QueryText, Interpolations) ->
 %%      tuple.
 query(Pid, Query, Interpolations, Cover)
   when is_pid(Pid), is_list(Query) ->
-    Message = riakc_ts_query_operator:serialize(Query, Interpolations),
+    Message = riakc_ts_query_operator:serialize(
+                lists:flatten(Query), Interpolations),
     Response = server_call(Pid, Message#tsqueryreq{cover_context = Cover}),
     riakc_ts_query_operator:deserialize(Response).
 

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -61,7 +61,12 @@ query(Pid, QueryText, Interpolations) ->
 %%      first element, and a list of records, each represented as a
 %%      list of values, in the second element, or an @{error, Reason@}
 %%      tuple.
-query(Pid, Query, Interpolations, Cover)
+query(Pid, Query, Interpolations, undefined) ->
+	query_common(Pid, Query, Interpolations, undefined);
+query(Pid, Query, Interpolations, Cover) when is_binary(Cover) ->
+	query_common(Pid, Query, Interpolations, Cover).
+
+query_common(Pid, Query, Interpolations, Cover)
   when is_pid(Pid), is_list(Query) ->
     Message = riakc_ts_query_operator:serialize(
                 iolist_to_binary(Query), Interpolations),

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -37,91 +37,74 @@
 -include_lib("riak_pb/include/riak_ts_ttb.hrl").
 -include("riakc.hrl").
 
--type table_name() :: binary().
+-type table_name() :: string()|binary().
 -type ts_value() :: riak_pb_ts_codec:ldbvalue().
 -type ts_columnname() :: riak_pb_ts_codec:tscolumnname().
 
--spec query(Pid::pid(), Query::string()) ->
+
+-spec query(pid(), Query::string()|binary()) ->
                    {ColumnNames::[ts_columnname()], Rows::[tuple()]} | {error, Reason::term()}.
-%% @doc Execute a "SELECT ..." Query with client.  The result returned
-%%      is a tuple containing a list of columns as binaries in the
-%%      first element, and a list of records, each represented as a
-%%      list of values, in the second element, or an @{error, Reason@}
-%%      tuple.
-%%
-
+%% @equiv query/4.
 query(Pid, QueryText) ->
-    query(Pid, QueryText, []).
+    query(Pid, QueryText, [], undefined).
 
--spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}]) ->
+-spec query(pid(), Query::string()|binary(), Interpolations::[{binary(), binary()}]) ->
                    {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
-%% @doc Execute a "SELECT ..." Query with client.  The result returned
-%%      is a tuple containing a list of columns as binaries in the
-%%      first element, and a list of records, each represented as a
-%%      list of values, in the second element, or an @{error, Reason@}
-%%      tuple.
-%%
-
+%% @equiv query/4.
 query(Pid, QueryText, Interpolations) ->
-    Message = riakc_ts_query_operator:serialize(QueryText, Interpolations),
-    Response = server_call(Pid, Message),
-    riakc_ts_query_operator:deserialize(Response).
+    query(Pid, QueryText, Interpolations, undefined).
 
--spec query(Pid::pid(), Query::string(), Interpolations::[{binary(), binary()}], Cover::term()) ->
+-spec query(pid(), Query::string(), Interpolations::[{binary(), binary()}], Cover::term()) ->
                    {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
-%% @doc Execute a "SELECT ..." Query with client.  The result returned
+%% @doc Execute a Query with client.  The result returned
 %%      is a tuple containing a list of columns as binaries in the
 %%      first element, and a list of records, each represented as a
 %%      list of values, in the second element, or an @{error, Reason@}
 %%      tuple.
-
-query(Pid, QueryText, Interpolations, Cover) ->
-    Message = riakc_ts_query_operator:serialize(QueryText, Interpolations),
-    Response = server_call(Pid, Message#tsqueryreq{cover_context=Cover}),
+query(Pid, Query, Interpolations, Cover)
+  when is_pid(Pid), is_list(Query) ->
+    Message = riakc_ts_query_operator:serialize(Query, Interpolations),
+    Response = server_call(Pid, Message#tsqueryreq{cover_context = Cover}),
     riakc_ts_query_operator:deserialize(Response).
 
+
+-spec get_coverage(pid(), table_name(), Query::string()) ->
+                          {ok, Entries::[term()]} | {error, term()}.
 %% @doc Generate a parallel coverage plan for the specified query
-get_coverage(Pid, Table, QueryText) ->
+get_coverage(Pid, Table, Query)
+  when is_pid(Pid), (is_binary(Table) orelse is_list(Table)), is_list(Query) ->
     server_call(Pid,
-                #tscoveragereq{query = #tsinterpolation{base=QueryText},
-                               replace_cover=undefined,
-                               table = Table}).
+                #tscoveragereq{query = #tsinterpolation{base = Query},
+                               replace_cover = undefined,
+                               table = ensure_binary(Table)}).
 
--spec put(Pid::pid(), Table::table_name(), [[ts_value()]]) ->
+
+-spec put(pid(), table_name(), [[ts_value()]]) ->
+                 ok | {error, Reason::term()}.
+%% @equiv put/4.
+put(Pid, Table, Measurements) ->
+    put(Pid, Table, [], Measurements).
+
+-spec put(pid(), table_name(), ColumnNames::[ts_columnname()], Data::[[ts_value()]]) ->
                  ok | {error, Reason::term()}.
 %% @doc Make data records from Data and insert them, individually,
 %%      into a time-series Table, using client Pid. Each record is a
 %%      list of values of appropriate types for the complete set of
 %%      table column names, in the order in which they appear in table's
 %%      DDL.  On success, 'ok' is returned, else an @{error, Reason@}
-%%      tuple.  Also @see put/3.
+%%      tuple.
 %%
 %%      As of 2015-11-05, ColumnNames parameter is ignored, the function
 %%      expects the full set of fields in each element of Data.
-%%
-
-put(Pid, TableName, Measurements) ->
-    put(Pid, TableName, [], Measurements).
-
--spec put(Pid::pid(), Table::table_name(), ColumnNames::[ts_columnname()], Data::[[ts_value()]]) ->
-                 ok | {error, Reason::term()}.
-%% @doc Make data records from Data and insert them, individually,
-%%      into a time-series Table, using client Pid. Each record is a
-%%      list of values of appropriate types for the complete set of
-%%      table column names, in the order in which they appear in table's
-%%      DDL.  On success, 'ok' is returned, else an @{error, Reason@}
-%%      tuple.  
-%%
-%%      As of 2015-11-05, ColumnNames parameter is ignored, the function
-%%      expects the full set of fields in each element of Data.
-%%
-
-put(Pid, TableName, ColumnNames, Measurements) ->
-    Message = riakc_ts_put_operator:serialize(TableName, ColumnNames, Measurements),
+put(Pid, Table, ColumnNames, Measurements)
+  when is_pid(Pid) andalso (is_binary(Table) orelse is_list(Table)) andalso
+       is_list(ColumnNames) andalso is_list(Measurements) ->
+    Message = riakc_ts_put_operator:serialize(Table, ColumnNames, Measurements),
     Response = server_call(Pid, Message),
     riakc_ts_put_operator:deserialize(Response).
 
--spec delete(Pid::pid(), Table::table_name(), Key::[ts_value()],
+
+-spec delete(pid(), table_name(), Key::[ts_value()],
              Options::proplists:proplist()) ->
                     ok | {error, Reason::term()}.
 %% @doc Delete a record, if there is one, having the fields
@@ -130,16 +113,17 @@ put(Pid, TableName, ColumnNames, Measurements) ->
 %%      a proplist which can include values for 'vclock' and
 %%      'timeout'.  Unless vclock is supplied, a get (@see get/4) is
 %%      called in order to obtain one.
-delete(Pid, TableName, Key, Options)
-  when is_list(Key) ->
-    Message = #tsdelreq{table   = TableName,
+delete(Pid, Table, Key, Options)
+  when is_pid(Pid), (is_binary(Table) orelse is_list(Table)),
+       is_list(Key), is_list(Options) ->
+    Message = #tsdelreq{table   = ensure_binary(Table),
                         key     = riak_pb_ts_codec:encode_cells_non_strict(Key),
                         vclock  = proplists:get_value(vclock, Options),
                         timeout = proplists:get_value(timeout, Options)},
     _Response = server_call(Pid, Message).
 
 
--spec get(Pid::pid(), Table::table_name(), Key::[ts_value()],
+-spec get(pid(), table_name(), Key::[ts_value()],
           Options::proplists:proplist()) ->
                  {ok, {Columns::[binary()], Record::[ts_value()]}} |
                  {error, {ErrCode::integer(), ErrMsg::binary()}}.
@@ -152,8 +136,10 @@ delete(Pid, TableName, Key, Options)
 %%      single element in enclosing list. If no record is found, the
 %%      return value is @{ok, @{[], []@}@}. On error, the function
 %%      returns @{error, @{ErrCode, ErrMsg@}@}.
-get(Pid, TableName, Key, Options) ->
-    Message = #tsgetreq{table   = TableName,
+get(Pid, Table, Key, Options)
+  when is_pid(Pid), (is_binary(Table) orelse is_list(Table)),
+       is_list(Key), is_list(Options) ->
+    Message = #tsgetreq{table   = ensure_binary(Table),
                         key     = Key,
                         timeout = proplists:get_value(timeout, Options)},
 
@@ -178,9 +164,10 @@ stream_list_keys(Pid, Table, infinity) ->
     stream_list_keys(Pid, Table, [{timeout, undefined}]);
 stream_list_keys(Pid, Table, Timeout) when is_integer(Timeout) ->
     stream_list_keys(Pid, Table, [{timeout, Timeout}]);
-stream_list_keys(Pid, Table, Options) ->
+stream_list_keys(Pid, Table, Options)
+  when is_pid(Pid), (is_binary(Table) orelse is_list(Table)), is_list(Options) ->
     ReqTimeout = proplists:get_value(timeout, Options),
-    Req = #tslistkeysreq{table = Table,
+    Req = #tslistkeysreq{table = ensure_binary(Table),
                          timeout = ReqTimeout},
     ReqId = riakc_pb_socket:mk_reqid(),
     gen_server:call(Pid, {req, Req, ?DEFAULT_PB_TIMEOUT, {ReqId, self()}}, infinity).
@@ -194,3 +181,7 @@ server_call(Pid, Message) ->
                     {req, Message, riakc_pb_socket:default_timeout(timeseries)},
                     infinity).
 
+ensure_binary(Table) when is_binary(Table) ->
+    Table;
+ensure_binary(Table) when is_list(Table) ->
+    iolist_to_binary(Table).


### PR DESCRIPTION
This PR:

* unbreaks some tests (ts_simple_aggregation and possibly others) which call riakc_ts functions with `Table` argument given as a string (not binary);
* introduces guards to parameters in all functions;
* cleans up docstrings.