### PR TITLE
Ensure strings are actually binaries in and out of the client

### DIFF
--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -31,10 +31,11 @@
 -export([serialize/3,
          deserialize/1]).
 
+
 serialize(TableName, ColumnNames, Measurements) ->
     ColumnDescs = riak_pb_ts_codec:encode_columnnames(ColumnNames),
     SerializedRows = riak_ttb_codec:encode_ts_rows(Measurements),
-    #tsputreq{table   = TableName,
+    #tsputreq{table   = riakc_ts:convert_to_binary(TableName),
               columns = ColumnDescs,
               rows    = SerializedRows}.
 

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -31,10 +31,9 @@
 -export([serialize/2,
          deserialize/1]).
 
-
 serialize(QueryText, Interpolations) ->
     Content = #tsinterpolation{
-                 base = QueryText,
+                 base = riakc_ts:convert_to_binary(QueryText),
                  interpolations = serialize_interpolations(Interpolations)},
     #tsqueryreq{query = Content}.
 
@@ -48,7 +47,12 @@ serialize_interpolations([{Key, Value} | RemainingInterps],
     UpdatedInterps = [#rpbpair{key=Key, value=Value} | SerializedInterps],
     serialize_interpolations(RemainingInterps, UpdatedInterps).
 
-deserialize({error, Message}) -> {error, Message};
+deserialize({error, {Code, Message}}) when is_integer(Code), is_list(Message) ->
+    {error, {Code, riakc_ts:convert_to_binary(Message)}};
+deserialize({error, {Code, Message}}) when is_integer(Code), is_atom(Message) ->
+    {error, {Code, riakc_ts:convert_to_binary(atom_to_list(Message))}};
+deserialize({error, Message}) ->
+    {error, Message};
 
 deserialize(#tsqueryresp{columns = {ColumnNames, _ColumnTypes}, rows = Rows}) ->
     {ColumnNames, Rows}.


### PR DESCRIPTION
With TTB encoding we no longer go through PBC which converted strings to binaries for us.  Do this now explicitly on certain fields.