### PR TITLE
Remove the column type from a TS get request

### DIFF
--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -153,7 +153,7 @@ get(Pid, Table, Key, Options)
         {error, OtherError} ->
             {error, OtherError};
         Response ->
-            Columns = Response#tsgetresp.columns,
+            {Columns, _Types} = Response#tsgetresp.columns,
             Rows = Response#tsgetresp.rows,
             {ok, {Columns, Rows}}
     end.


### PR DESCRIPTION
Column Type was included with TTB, so let's now remove it since it was not previously there.