### PR TITLE
Standardize the success response from tsgetresp and tsqueryresp

### DIFF
--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -43,13 +43,13 @@
 
 
 -spec query(pid(), Query::string()|binary()) ->
-                   {ColumnNames::[ts_columnname()], Rows::[tuple()]} | {error, Reason::term()}.
+            {ok, {ColumnNames::[ts_columnname()], Rows::[tuple()]}} | {error, Reason::term()}.
 %% @equiv query/5.
 query(Pid, Query) ->
     query(Pid, Query, [], undefined, []).
 
 -spec query(pid(), Query::string()|binary(), Interpolations::[{binary(), binary()}]) ->
-                   {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
+            {ok, {ColumnNames::[binary()], Rows::[tuple()]}} | {error, term()}.
 %% @equiv query/5.
 query(Pid, Query, Interpolations) ->
     query(Pid, Query, Interpolations, undefined, []).
@@ -58,7 +58,7 @@ query(Pid, Query, Interpolations) ->
             Query::string(),
             Interpolations::[{binary(), binary()}],
             Cover::term()) ->
-            {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
+            {ok, {ColumnNames::[binary()], Rows::[tuple()]}} | {error, term()}.
 %% @equiv query/5.
 query(Pid, Query, Interpolations, Cover) ->
     query(Pid, Query, Interpolations, Cover, []).
@@ -68,7 +68,7 @@ query(Pid, Query, Interpolations, Cover) ->
             Interpolations::[{binary(), binary()}],
             Cover::term(),
             Options::proplists:proplist()) ->
-            {ColumnNames::[binary()], Rows::[tuple()]} | {error, term()}.
+            {ok, {ColumnNames::[binary()], Rows::[tuple()]}} | {error, term()}.
 %% @doc Execute a Query with client.  The result returned
 %%      is a tuple containing a list of columns as binaries in the
 %%      first element, and a list of records, each represented as a

--- a/src/riakc_ts_get_operator.erl
+++ b/src/riakc_ts_get_operator.erl
@@ -48,8 +48,6 @@ deserialize({error, Message}) ->
     {error, Message};
 deserialize(tsgetresp) ->
     {ok, {[], []}};
-deserialize({tsgetresp, {_, _, []}}) ->
-    {[], []};
 deserialize({tsgetresp, {ColumnNames, _ColumnTypes, Rows}}) ->
     {ok, {ColumnNames, Rows}};
 deserialize(#tsgetresp{columns = C, rows = R}) ->

--- a/src/riakc_ts_get_operator.erl
+++ b/src/riakc_ts_get_operator.erl
@@ -48,6 +48,8 @@ deserialize({error, Message}) ->
     {error, Message};
 deserialize(tsgetresp) ->
     {ok, {[], []}};
+deserialize({tsgetresp, {_, _, []}}) ->
+    {[], []};
 deserialize({tsgetresp, {ColumnNames, _ColumnTypes, Rows}}) ->
     {ok, {ColumnNames, Rows}};
 deserialize(#tsgetresp{columns = C, rows = R}) ->

--- a/src/riakc_ts_get_operator.erl
+++ b/src/riakc_ts_get_operator.erl
@@ -46,6 +46,8 @@ deserialize({error, {Code, Message}}) when is_integer(Code), is_atom(Message) ->
     {error, {Code, iolist_to_binary(atom_to_list(Message))}};
 deserialize({error, Message}) ->
     {error, Message};
+deserialize(tsgetresp) ->
+    {ok, {[], []}};
 deserialize({tsgetresp, {ColumnNames, _ColumnTypes, Rows}}) ->
     {ok, {ColumnNames, Rows}};
 deserialize(#tsgetresp{columns = C, rows = R}) ->

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -54,12 +54,10 @@ deserialize({error, {Code, Message}}) when is_integer(Code), is_atom(Message) ->
 deserialize({error, Message}) ->
     {error, Message};
 deserialize(tsqueryresp) ->
-    {[], []};
-deserialize({tsqueryresp, {_, _, []}}) ->
-    {[], []};
+    {ok, {[], []}};
 deserialize({tsqueryresp, {ColumnNames, _ColumnTypes, Rows}}) ->
-    {ColumnNames, Rows};
+    {ok, {ColumnNames, Rows}};
 deserialize(#tsqueryresp{columns = C, rows = R}) ->
     ColumnNames = [ColName || #tscolumndescription{name = ColName} <- C],
     Rows = riak_pb_ts_codec:decode_rows(R),
-    {ColumnNames, Rows}.
+    {ok, {ColumnNames, Rows}}.


### PR DESCRIPTION
This is consistent with the `tsqueryresp` case, too.