### PR TITLE
Fixup az post ttb and develop merge

### DIFF
--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -75,9 +75,9 @@ query(Pid, Query, Interpolations, Cover) ->
 %%      list of values, in the second element, or an @{error, Reason@}
 %%      tuple.
 query(Pid, Query, Interpolations, undefined, Options) ->
-	query_common(Pid, Query, Interpolations, undefined, Options);
+        query_common(Pid, Query, Interpolations, undefined, Options);
 query(Pid, Query, Interpolations, Cover, Options) when is_binary(Cover) ->
-	query_common(Pid, Query, Interpolations, Cover, Options).
+        query_common(Pid, Query, Interpolations, Cover, Options).
 
 query_common(Pid, Query, Interpolations, Cover, Options)
   when is_pid(Pid), is_list(Query) ->


### PR DESCRIPTION
Relates to https://github.com/basho/riak_kv/pull/1382, requires https://github.com/basho/riak_pb/pull/190.

Contains a fix for the case of `riakc_ts:get` returning an empty set, where the client connection is broken with an error message implicating 'tsgetresp'.

Also, properly decode the error message of `get_coverage` (previously, this was done in riak_kv_ts_svc, which is not the right place for assembling `#ts...` records since this module now serves PB as well as TTB messages).