### PR TITLE
Streaming Queries

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1980,12 +1980,14 @@ process_response(#request{msg = #tslistkeysreq{}} = Request,
 process_response(#request{msg = #tsqueryreq{ }} = Request,
                  #tsqueryresp{done = Done, rows = Rows},
                  #state{ active = Req } = State) when Req /= undefined ->
-    case Rows of
-        [_|_] ->
-            send_caller({rows, riak_pb_ts_codec:decode_rows(Rows)}, Request);
-        _ ->
-            ok
-    end,
+    %% match on an underscore to make dialyzer happy...
+    _ =
+        case Rows of
+            [_|_] ->
+                send_caller({rows, riak_pb_ts_codec:decode_rows(Rows)}, Request);
+            _ ->
+                ok
+        end,
     case Done of
         true ->
             {reply, done, State};

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1983,12 +1983,12 @@ process_response(#request{msg = #tsqueryreq{ }} = Request,
     ColNames = tsresponse_column_names(RespProps),
     Done = tsresponse_done(RespProps),
     Rows = tsresponse_rows(RespProps),
-    SubQueryId = tsresponse_sub_query_id(RespProps),
+    Continuation = tsresponse_cotinuation(RespProps),
     %% match on an underscore to make dialyzer happy...
     _ =
         case Rows of
             [_|_] ->
-                send_caller({rows, SubQueryId, ColNames, Rows}, Request);
+                send_caller({rows, Continuation, ColNames, Rows}, Request);
             _ ->
                 ok
         end,
@@ -2544,8 +2544,8 @@ tsresponse_done(RespProps) ->
 tsresponse_rows(RespProps) ->
     proplists:get_value(rows, RespProps).
 
-tsresponse_sub_query_id(RespProps) ->
-    proplists:get_value(sub_query_id, RespProps).
+tsresponse_cotinuation(RespProps) ->
+    proplists:get_value(cotinuation, RespProps).
 
 %% ====================================================================
 %% unit tests

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -42,16 +42,23 @@
 -type ts_value() :: riak_pb_ts_codec:ldbvalue().
 -type ts_columnname() :: riak_pb_ts_codec:tscolumnname().
 
+%% @doc Message types sent to the calling process of stream_query/4
+-type stream_query_chunk() ::
+    {rows, Continuation::binary(), ColumnNames::[binary()], Rows::[tuple()]}.
+-type stream_result() ::
+    {ReqId::non_neg_integer(), stream_query_chunk() | done}.
+
+-export_type([stream_result/0, stream_query_chunk/0]).
 
 -spec query(pid(), Query::string()|binary()) ->
             {ok, {ColumnNames::[ts_columnname()], Rows::[tuple()]}} | {error, Reason::term()}.
-%% @equiv query/5.
+%% @equiv query/5
 query(Pid, Query) ->
     query(Pid, Query, [], undefined, []).
 
 -spec query(pid(), Query::string()|binary(), Interpolations::[{binary(), binary()}]) ->
             {ok, {ColumnNames::[binary()], Rows::[tuple()]}} | {error, term()}.
-%% @equiv query/5.
+%% @equiv query/5
 query(Pid, Query, Interpolations) ->
     query(Pid, Query, Interpolations, undefined, []).
 
@@ -60,7 +67,7 @@ query(Pid, Query, Interpolations) ->
             Interpolations::[{binary(), binary()}],
             Cover::term()) ->
             {ok, {ColumnNames::[binary()], Rows::[tuple()]}} | {error, term()}.
-%% @equiv query/5.
+%% @equiv query/5
 query(Pid, Query, Interpolations, Cover) ->
     query(Pid, Query, Interpolations, Cover, []).
 
@@ -70,7 +77,7 @@ query(Pid, Query, Interpolations, Cover) ->
             Cover::term(),
             Options::proplists:proplist()) ->
             {ok, {ColumnNames::[binary()], Rows::[tuple()]}} | {error, term()}.
-%% @doc Execute a Query with client.  The result returned
+%% @doc Execute a Query.  The result returned
 %%      is a tuple containing a list of columns as binaries in the
 %%      first element, and a list of records, each represented as a
 %%      list of values, in the second element, or an @{error, Reason@}
@@ -96,7 +103,10 @@ stream_query(Pid, Query) when is_pid(Pid),
                               is_list(Query) ->
     stream_query(Pid, Query, [], []).
 
-%%
+%% @doc
+%% Execute a streamed query. The immediate result
+%% is a reference to the request ID. This will be used in messages
+%% sent asynchronously from the socket process.
 -spec stream_query(ClientPid::pid(),
                    QueryString::string(),
                    Interpolations::[{binary(), binary()}],
@@ -131,7 +141,7 @@ get_coverage(Pid, Table, Query) ->
 -spec put(pid(),
           table_name(),
           [[ts_value()]]) -> ok | {error, Reason::term()}.
-%% @equiv put/4.
+%% @equiv put/4
 put(Pid, Table, Measurements) ->
     put(Pid, Table, Measurements, []).
 

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -91,8 +91,8 @@ query_common(Pid, Query, Interpolations, Cover, Options)
 
 %%
 stream_query(Pid, Query, Interpolations, _Options) when is_pid(Pid),
-                                                       is_list(Query) ->
-    Stream = false,
+                                                        is_list(Query) ->
+    Stream = true,
     Msg1 = riakc_ts_query_operator:serialize(Query, Interpolations, Stream),
     % Msg2 = {Msg1, {msgopts, Options}},
     ReqId = riakc_pb_socket:mk_reqid(),

--- a/src/riakc_ts_get_operator.erl
+++ b/src/riakc_ts_get_operator.erl
@@ -20,6 +20,7 @@
 %%
 %% -------------------------------------------------------------------
 
+%% @hidden
 %% @doc Helper functions for put requests to Riak TS
 
 -module(riakc_ts_get_operator).

--- a/src/riakc_ts_put_operator.erl
+++ b/src/riakc_ts_put_operator.erl
@@ -20,6 +20,7 @@
 %%
 %% -------------------------------------------------------------------
 
+%% @hidden
 %% @doc Helper functions for put requests to Riak TS
 
 -module(riakc_ts_put_operator).

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -28,14 +28,14 @@
 -include_lib("riak_pb/include/riak_ts_pb.hrl").
 -include_lib("riak_pb/include/riak_ts_ttb.hrl").
 
--export([serialize/2,
+-export([serialize/3,
          deserialize/1]).
 
-serialize(QueryText, Interpolations) ->
+serialize(QueryText, Interpolations, Stream) ->
     Content = #tsinterpolation{
                  base           = iolist_to_binary(QueryText),
                  interpolations = serialize_interpolations(Interpolations)},
-    #tsqueryreq{query = Content}.
+    #tsqueryreq{query = Content, stream = Stream}.
 
 serialize_interpolations(Interpolations) ->
     serialize_interpolations(Interpolations, []).

--- a/src/riakc_ts_query_operator.erl
+++ b/src/riakc_ts_query_operator.erl
@@ -20,6 +20,7 @@
 %%
 %% -------------------------------------------------------------------
 
+%% @hidden
 %% @doc Helper functions for query requests to Riak TS
 
 -module(riakc_ts_query_operator).


### PR DESCRIPTION
**Ready for Review, please do NOT merge**

PRs for streaming queries.

 + https://github.com/basho/riak_kv/pull/1415
 + https://github.com/basho/riak-erlang-client/pull/281
 + https://github.com/basho/riak_test/pull/1072

#### Function `riakc_ts:stream_query/4`.

This sets the pre-existing `done` field in `#tsqueryreq` to `true`.  Riak TS will send one result message per sub query (not guaranteed in the future) containing the result set and request metadata. Once all result messages have been sent a final `done` message is sent. Formats are:

```erlang
{ReqId, {rows, Continuation, ColumnNames, Rows}}.
{ReqId, done}.
```


The message sent from Riak to the client is a ttb encoded message.

```erlang
{tsresponse, [
      {column_names, ColNames::[binary()]},
      {column_types, ColTypes::[riak_ql_ddl:simple_field_type()]},
      {done, boolean()},
      {rows, [tuple()]},
      {continuation, binary()}
]}.
```

The message from Riak where the query is done.

```erlang
{tsresponse, [
      {column_names, []},
      {column_types, []},
      {done, true},
      {rows, []}
]}.
```

The continuation is an opaque binary, similar to 2i. It not used in this piece (it will be used to stream unlimited chunks with back pressure) but can be used to sort the queries. The continuation from query one will be less than query two using erlang binary comparison.