### PR TITLE
Strip 'create' option from riakc_pb_socket:modify_type

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1254,8 +1254,10 @@ update_type(Pid, BucketAndType, Key, {Type, Op, Context}, Options) ->
 -spec modify_type(pid(), fun((riakc_datatype:datatype()) -> riakc_datatype:datatype()),
                   bucket_and_type(), Key::binary(), [proplists:property()]) ->
                          ok | {ok, riakc_datatype:datatype()} | {error, term()}.
-modify_type(Pid, Fun, BucketAndType, Key, Options) ->
-    Create = proplists:get_value(create, Options, true),
+modify_type(Pid, Fun, BucketAndType, Key, ModifyOptions) ->
+    Create = proplists:get_value(create, ModifyOptions, true),
+    Options = proplists:delete(create, ModifyOptions),
+
     case fetch_type(Pid, BucketAndType, Key, Options) of
         {ok, Data} ->
             NewData = Fun(Data),


### PR DESCRIPTION
Supercedes #203 (CLIENTS-151)