### PR TITLE
Detail mapreduce inputs type

### DIFF
--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -44,6 +44,7 @@
 -type bucket_type() :: binary().
 -type bucket_and_type() :: {bucket_type(), bucket()}.
 -type key() :: binary(). %% A key name.
+-type key_data() :: undefined | term().
 -type riakc_obj() :: riakc_obj:riakc_obj(). %% An object (bucket, key, metadata, value) stored in Riak.
 -type req_id() :: non_neg_integer(). %% Request identifier for streaming requests.
 -type server_prop() :: {node, binary()} | {server_version, binary()}. %% Server properties, as returned by the `get_server_info/1' call.
@@ -116,9 +117,10 @@
 %% function, that when evaluated points to a built-in javascript function.
 -type mapred_result() :: [term()].
 %% The results of a MapReduce job.
--type mapred_inputs() :: [{bucket(), key()} | {{bucket(), key()}, term()}] |
+-type mapred_inputs() :: bucket() |
+                         bucket_and_type() |
+                         [{bucket(), key()} | {{bucket_and_type(), key()}, key_data()} | {{bucket(), key()}, key_data()}] |
                          {modfun, Module::atom(), Function::atom(), [term()]} |
-                         bucket() |
                          {index, bucket(), Index::binary()|secondary_index_id(), key()|integer()} |
                          {index, bucket(), Index::binary()|secondary_index_id(), StartKey::key()|integer(), EndKey::key()|integer()}.
 %% Inputs for a MapReduce job.


### PR DESCRIPTION
Include bucket type and clarify key-data.

Refs:
- https://github.com/basho/riak_kv/blob/edce9a29ed31a6877c8a861ceea0fcb6d7d8832a/src/riak_kv_mapred_term.erl#L45
- https://github.com/basho/basho_docs/blob/de152b49e29fdf3845c5a54171aa8f665cf0367d/content/riak/kv/2.1.4/developing/app-guide/advanced-mapreduce.md#inputs
