### PR TITLE
drop the disused allow_qbuf_reuse flag

### DIFF
--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -82,10 +82,8 @@
 
 query_common(Pid, Query, Interpolations, Cover, Options)
   when is_pid(Pid) ->
-    AllowQBufReuse = (true == proplists:get_value(allow_qbuf_reuse, Options)),
     Msg0 = riakc_ts_query_operator:serialize(Query, Interpolations),
-    Msg1 = Msg0#tsqueryreq{cover_context = Cover,
-                           allow_qbuf_reuse = AllowQBufReuse},
+    Msg1 = Msg0#tsqueryreq{cover_context = Cover},
     Msg = {Msg1, {msgopts, Options}},
     Response = server_call(Pid, Msg),
     riakc_ts_query_operator:deserialize(Response,


### PR DESCRIPTION
Required by https://github.com/basho/riak_test/pull/1213 (and eventually by https://github.com/basho/riak_kv/pull/1549). Depends on https://github.com/basho/riak_pb/pull/212.

That flag did not pass the scrutiny of three-strong panel of reviewers.