### PR TITLE
Fix error condition output of streaming operations to have binary() reason [RTS-1602]

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -459,8 +459,8 @@ list_buckets(Pid, Type, Options) when is_binary(Type), is_list(Options) ->
     case stream_list_buckets(Pid, Type, Options) of
         {ok, ReqId} ->
             riakc_utils:wait_for_list(ReqId);
-        Error ->
-            Error
+        {error, Reason} ->
+            {error, riakc_utils:to_binary(Reason)}
     end.
 
 stream_list_buckets(Pid) ->

--- a/src/riakc_utils.erl
+++ b/src/riakc_utils.erl
@@ -22,7 +22,9 @@
 
 -module(riakc_utils).
 
--export([wait_for_list/1, characters_to_unicode_binary/1]).
+-export([wait_for_list/1,
+         characters_to_unicode_binary/1,
+         to_binary/1]).
 
 -spec wait_for_list(non_neg_integer()) -> {ok, list()} | {error, any()}.
 %% @doc Wait for the results of a listing operation
@@ -30,9 +32,12 @@ wait_for_list(ReqId) ->
     wait_for_list(ReqId, []).
 wait_for_list(ReqId, Acc) ->
     receive
-        {ReqId, done} -> {ok, lists:flatten(Acc)};
-        {ReqId, {error, Reason}} -> {error, Reason};
-        {ReqId, {_, Res}} -> wait_for_list(ReqId, [Res|Acc])
+        {ReqId, done} ->
+              {ok, lists:flatten(Acc)};
+        {ReqId, {error, Reason}} ->
+              {error, to_binary(Reason)};
+        {ReqId, {_, Res}} ->
+              wait_for_list(ReqId, [Res|Acc])
     end.
 
 -spec characters_to_unicode_binary(string()|binary()) -> binary().
@@ -49,3 +54,8 @@ characters_to_unicode_binary(String) ->
         Binary ->
             Binary
     end.
+
+-spec to_binary(atom()|iolist()|binary()) -> binary().
+%% @doc Convert to binary, additionally supporting atom().
+to_binary(V) when is_atom(V) -> to_binary(atom_to_list(V));
+to_binary(V) -> iolist_to_binary(V).


### PR DESCRIPTION
Reviewers (if I may suggest):
- @fadushin Please review since you peered into the regression test failure for a bit before.
- @alexmoore or @lukebakken being the resident erlang client experts, please review as well.

Summary:
This fixes regression test break riak_test verify_api_timeouts.

Features:
* fixed error condition output of streaming operations expected to be in the form `{error, binary()}`, but was `{error, atom()}`.