### PR TITLE
Implement errors for listing operations.

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -752,6 +752,17 @@ mapred_stream(Pid, {index,Bucket,Name,StartKey,EndKey}, Query, ClientPid, Timeou
     BinEndKey = list_to_binary(integer_to_list(EndKey)),
     mapred_stream(Pid, {index,Bucket,Name,StartKey,BinEndKey}, Query, ClientPid, Timeout, CallTimeout);
 mapred_stream(Pid, Inputs, Query, ClientPid, Timeout, _CallTimeout) ->
+    AllowListing = riakc_utils:get_allow_listing(),
+    do_mapred_stream(AllowListing, Pid, Inputs, Query, ClientPid, Timeout).
+
+do_mapred_stream(false, _Pid, Bucket, _Query, _ClientPid, _Timeout) when is_binary(Bucket) ->
+    {error, <<"Bucket list operations are expensive "
+              "and should not be used in production.">>};
+do_mapred_stream(false, _Pid, {Type, Bucket}, _Query, _ClientPid, _Timeout)
+  when is_binary(Type), is_binary(Bucket) ->
+    {error, <<"Bucket list operations are expensive "
+              "and should not be used in production.">>};
+do_mapred_stream(_AllowListing, Pid, Inputs, Query, ClientPid, Timeout) ->
     MapRed = [{'inputs', Inputs},
               {'query', Query},
               {'timeout', Timeout}],

--- a/src/riakc_ts.erl
+++ b/src/riakc_ts.erl
@@ -224,6 +224,13 @@ stream_list_keys(Pid, Table, Timeout) when is_integer(Timeout) ->
     stream_list_keys(Pid, Table, [{timeout, Timeout}]);
 stream_list_keys(Pid, Table, Options)
   when is_pid(Pid), (is_binary(Table) orelse is_list(Table)), is_list(Options) ->
+    AllowListing = riakc_utils:get_allow_listing(Options),
+    do_stream_list_keys(AllowListing, Pid, Table, Options).
+
+do_stream_list_keys(false, _Pid, _Table, _Options) ->
+    {error, <<"Bucket and key list operations are expensive "
+              "and should not be used in production.">>};
+do_stream_list_keys(true, Pid, Table, Options) ->
     T = riakc_utils:characters_to_unicode_binary(Table),
     ReqTimeout = proplists:get_value(timeout, Options),
     Req = #tslistkeysreq{table = T, timeout = ReqTimeout},

--- a/src/riakc_utils.erl
+++ b/src/riakc_utils.erl
@@ -24,6 +24,7 @@
 
 -export([wait_for_list/1,
          characters_to_unicode_binary/1,
+         get_allow_listing/0,
          get_allow_listing/1]).
 
 -spec wait_for_list(non_neg_integer()) -> {ok, list()} | {error, any()}.
@@ -54,6 +55,13 @@ characters_to_unicode_binary(String) ->
 
 %% @doc Return the value of allow_listing, which, if set to 'true`
 %%      will allow listing keys and buckets.
+-spec get_allow_listing() -> boolean().
+get_allow_listing() ->
+    case application:get_env(riakc, allow_listing) of
+        {ok, true} -> true;
+        _ -> false
+    end.
+
 -spec get_allow_listing(proplists:proplist()) -> boolean().
 get_allow_listing(Options) ->
     case application:get_env(riakc, allow_listing) of

--- a/src/riakc_utils.erl
+++ b/src/riakc_utils.erl
@@ -22,7 +22,9 @@
 
 -module(riakc_utils).
 
--export([wait_for_list/1, characters_to_unicode_binary/1]).
+-export([wait_for_list/1,
+         characters_to_unicode_binary/1,
+         get_allow_listing/1]).
 
 -spec wait_for_list(non_neg_integer()) -> {ok, list()} | {error, any()}.
 %% @doc Wait for the results of a listing operation
@@ -48,4 +50,17 @@ characters_to_unicode_binary(String) ->
             throw({unicode_error, ErrMsg});
         Binary ->
             Binary
+    end.
+
+%% @doc Return the value of allow_listing, which, if set to 'true`
+%%      will allow listing keys and buckets.
+-spec get_allow_listing(proplists:proplist()) -> boolean().
+get_allow_listing(Options) ->
+    case application:get_env(riakc, allow_listing) of
+        {ok, true} -> true;
+        _ ->
+            case proplists:get_value(allow_listing, Options) of
+                true -> true;
+                _ -> false
+            end
     end.

--- a/test/riakc_pb_socket_tests.erl
+++ b/test/riakc_pb_socket_tests.erl
@@ -37,6 +37,16 @@ listing_is_blocked_test() ->
     ?assertMatch({error, E}, riakc_pb_socket:list_keys(self(), <<"b">>)),
     application:set_env(riakc, allow_listing, true).
 
+mapred_over_bucket_is_blocked_test() ->
+    application:set_env(riakc, allow_listing, false),
+    Pid = self(),
+    Input1 = <<"bucket">>,
+    Input2 = {<<"type">>, <<"bucket">>},
+    E = <<"Bucket list operations are expensive and should not be used in production.">>,
+    ?assertMatch({error, E}, riakc_pb_socket:mapred(Pid, Input1, [])),
+    ?assertMatch({error, E}, riakc_pb_socket:mapred(Pid, Input2, [])),
+    application:set_env(riakc, allow_listing, true).
+
 bad_connect_test() ->
     %% Start with an unlikely port number
     ?assertMatch({error, {tcp, econnrefused}}, riakc_pb_socket:start({127,0,0,1}, 65535)).

--- a/test/riakc_pb_socket_tests.erl
+++ b/test/riakc_pb_socket_tests.erl
@@ -30,24 +30,35 @@
 -include_lib("riak_pb/include/riak_pb_kv_codec.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+listing_is_blocked_test() ->
+    application:set_env(riakc, allow_listing, false),
+    E = <<"Bucket and key list operations are expensive and should not be used in production.">>,
+    ?assertMatch({error, E}, riakc_pb_socket:list_buckets(self())),
+    ?assertMatch({error, E}, riakc_pb_socket:list_keys(self(), <<"b">>)),
+    application:set_env(riakc, allow_listing, true).
+
 bad_connect_test() ->
     %% Start with an unlikely port number
-    ?assertEqual({error, {tcp, econnrefused}}, riakc_pb_socket:start({127,0,0,1}, 65535)).
+    ?assertMatch({error, {tcp, econnrefused}}, riakc_pb_socket:start({127,0,0,1}, 65535)).
 
 queue_disconnected_test() ->
+    application:set_env(riakc, allow_listing, true),
     %% Start with an unlikely port number
     {ok, Pid} = riakc_pb_socket:start({127,0,0,1}, 65535, [queue_if_disconnected]),
-    ?assertEqual({error, timeout}, riakc_pb_socket:ping(Pid, 10)),
-    ?assertEqual({error, timeout}, riakc_pb_socket:list_keys(Pid, <<"b">>, 10)),
-    riakc_pb_socket:stop(Pid).
+    ?assertMatch({error, timeout}, riakc_pb_socket:ping(Pid, 10)),
+    ?assertMatch({error, timeout}, riakc_pb_socket:list_keys(Pid, <<"b">>, 10)),
+    riakc_pb_socket:stop(Pid),
+    application:set_env(riakc, allow_listing, false).
 
 auto_reconnect_bad_connect_test() ->
+    application:set_env(riakc, allow_listing, true),
     %% Start with an unlikely port number
     {ok, Pid} = riakc_pb_socket:start({127,0,0,1}, 65535, [auto_reconnect]),
-    ?assertEqual({false, []}, riakc_pb_socket:is_connected(Pid)),
-    ?assertEqual({error, disconnected}, riakc_pb_socket:ping(Pid)),
-    ?assertEqual({error, disconnected}, riakc_pb_socket:list_keys(Pid, <<"b">>)),
-    riakc_pb_socket:stop(Pid).
+    ?assertMatch({false, []}, riakc_pb_socket:is_connected(Pid)),
+    ?assertMatch({error, disconnected}, riakc_pb_socket:ping(Pid)),
+    ?assertMatch({error, disconnected}, riakc_pb_socket:list_keys(Pid, <<"b">>)),
+    riakc_pb_socket:stop(Pid),
+    application:set_env(riakc, allow_listing, false).
 
 server_closes_socket_test() ->
     %% Silence SASL junk when socket closes.
@@ -69,7 +80,7 @@ server_closes_socket_test() ->
     ok = gen_tcp:close(Listen),
     receive
         Msg1 -> % result of ping from spawned process above
-            ?assertEqual({error, disconnected}, Msg1)
+            ?assertMatch({error, disconnected}, Msg1)
     end,
     %% Wait for spawned process to exit
     Mref = erlang:monitor(process, Pid),
@@ -96,7 +107,7 @@ auto_reconnect_server_closes_socket_test() ->
     ok = gen_tcp:close(Listen),
     receive
         Msg ->
-            ?assertEqual({error, disconnected}, Msg)
+            ?assertMatch({error, disconnected}, Msg)
     end,
     %% Server will not have had a chance to reconnect yet, reason counters empty.
     ?assertMatch({false, []}, riakc_pb_socket:is_connected(Pid)),
@@ -139,8 +150,8 @@ integration_tests() ->
     [{"ping",
       ?_test( begin
                   {ok, Pid} = riakc_test_utils:start_link(),
-                  ?assertEqual(pong, riakc_pb_socket:ping(Pid)),
-                  ?assertEqual(true, riakc_pb_socket:is_connected(Pid)),
+                  ?assertMatch(pong, riakc_pb_socket:ping(Pid)),
+                  ?assertMatch(true, riakc_pb_socket:is_connected(Pid)),
                   riakc_pb_socket:stop(Pid)
               end)},
 
@@ -1408,9 +1419,13 @@ integration_test_() ->
     SetupFun = fun() ->
                    %% Grab the riakclient_pb.proto file
                    code:add_pathz("../ebin"),
-                   ok = riakc_test_utils:maybe_start_network()
+                   ok = riakc_test_utils:maybe_start_network(),
+                   application:set_env(riakc, allow_listing, true)
                end,
-    CleanupFun = fun(_) -> net_kernel:stop() end,
+    CleanupFun = fun(_) ->
+                    net_kernel:stop(),
+                    application:set_env(riakc, allow_listing, false)
+                 end,
     GenFun = fun() ->
                  case catch net_adm:ping(riakc_test_utils:test_riak_node()) of
                      pong -> integration_tests();


### PR DESCRIPTION
Add code to return error when listing objects unless the `allow_listing` option is true.

Fixes #345 (CLIENTS-1067) (CLIENTS-1067) (CLIENTS-1067) and [`CLIENTS-1067`](https://bashoeng.atlassian.net/browse/CLIENTS-1067)