### PR TITLE
Port PR 351 to release-2.5.3

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1225,7 +1225,7 @@ fetch_type(Pid, BucketAndType, Key, Options) ->
 
 %% @doc Updates the convergent datatype in Riak with local
 %% modifications stored in the container type.
--spec update_type(pid(), bucket_and_type(), Key::binary(), Update::riakc_datatype:update(term())) ->
+-spec update_type(pid(), bucket_and_type(), Key::binary()|'undefined', Update::riakc_datatype:update(term())) ->
                          ok | {ok, Key::binary()} | {ok, riakc_datatype:datatype()} |
                          {ok, Key::binary(), riakc_datatype:datatype()} | {error, term()}.
 update_type(Pid, BucketAndType, Key, Update) ->
@@ -1234,7 +1234,7 @@ update_type(Pid, BucketAndType, Key, Update) ->
 %% @doc Updates the convergent datatype in Riak with local
 %% modifications stored in the container type, using the given request
 %% options.
--spec update_type(pid(), bucket_and_type(), Key::binary(),
+-spec update_type(pid(), bucket_and_type(), Key::binary()|'undefined',
                   Update::riakc_datatype:update(term()), [proplists:property()]) ->
                          ok | {ok, Key::binary()} | {ok, riakc_datatype:datatype()} |
                          {ok, Key::binary(), riakc_datatype:datatype()} | {error, term()}.

--- a/test/riakc_pb_socket_tests.erl
+++ b/test/riakc_pb_socket_tests.erl
@@ -999,6 +999,25 @@ integration_tests() ->
                     1 == Result#search_results.num_found
                 end )
          end)}},
+     {"updating without a key should generate one",
+         ?_test(begin
+                    riakc_test_utils:reset_riak(),
+                    {ok, Pid} = riakc_test_utils:start_link(),
+                    Res1 = riakc_pb_socket:update_type(Pid,
+                                     {<<"sets">>, <<"bucket">>}, undefined,
+                                     riakc_set:to_op(riakc_set:add_element(<<"X">>, riakc_set:new()))),
+                    Res2 = riakc_pb_socket:update_type(Pid,
+                                     {<<"sets">>, <<"bucket">>}, undefined,
+                                     riakc_set:to_op(riakc_set:add_element(<<"Y">>, riakc_set:new()))),
+                    ?assertMatch({ok, _K}, Res1),
+                    ?assertMatch({ok, _K}, Res2),
+                    {ok, K1} = Res1,
+                    {ok, K2} = Res2,
+                    ?assertMatch(true, is_binary(K1)),
+                    ?assertMatch(true, is_binary(K2)),
+                    % Make sure the same key isn't generated twice
+                    ?assert(Res1 =/= Res2)
+             end)},
      {"trivial set delete",
          ?_test(begin
                     riakc_test_utils:reset_riak(),


### PR DESCRIPTION
Expose CRDT update without key delegating key generation to Riak

Optional key in request and Riak-generated key are [documented
already](https://github.com/basho/basho_docs/blob/814125935ca55a5801764dcb780534a89b599dec/content/riak/kv/2.2.0/developing/api/protocol-buffers/dt-store.md#optional-parameters).

PB encoder [already has type
spec](https://github.com/basho/riak_pb/blob/4198223ec788401da5cbf2868e3181b6b5db289a/src/riak_pb_dt_codec.erl#L490-L494)
catering for optional key.