### PR TITLE
Fix dialyzer warnings in riakc_obj and riak_pb_socket

### DIFF
--- a/src/riakc_obj.erl
+++ b/src/riakc_obj.erl
@@ -109,12 +109,12 @@
 -type ttl() :: non_neg_integer().
 
 -record(riakc_obj, {
-          bucket :: bucket(),
+          bucket :: bucket() | undefined,
           key :: key(),
-          vclock :: vclock(),
+          vclock :: vclock() | undefined,
           contents :: contents(),
-          updatemetadata :: metadata(),
-          updatevalue :: value()
+          updatemetadata :: metadata() | undefined,
+          updatevalue :: value() | undefined
          }).
 
 -type riakc_obj() :: #riakc_obj{}. %% The record/type containing the entire Riak object.

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -160,7 +160,7 @@
                 auto_reconnect = false :: boolean(), % if true, automatically reconnects to server
                                         % if false, exits on connection failure/request timeout
                 queue_if_disconnected = false :: boolean(), % if true, add requests to queue if disconnected
-                sock :: port() | ssl:sslsocket(),       % gen_tcp socket
+                sock :: port() | ssl:sslsocket() | undefined,       % gen_tcp socket
                 keepalive = false :: boolean(), % if true, enabled TCP keepalive for the socket
                 transport = gen_tcp :: 'gen_tcp' | 'ssl',
                 active :: #request{} | undefined,     % active request


### PR DESCRIPTION
Erlang 19 reverts the behaviour that automagically inserted `'undefined'` as a valid type for all record fields. That caused some dialyzer warnings in riakc_obj and riak_pb_socket which this change fixes.
(Note that this doesn't fix all the dialyzer warnings - I think some originate in riak_pb - but one thing at a time).