### PR TITLE
Improve typespec for riakc_obj:update_value/3

### DIFF
--- a/src/riakc_obj.erl
+++ b/src/riakc_obj.erl
@@ -284,7 +284,7 @@ update_content_type(Object=#riakc_obj{}, CT) when is_list(CT) ->
 update_value(Object=#riakc_obj{}, V) -> Object#riakc_obj{updatevalue=V}.
 
 %% @doc  Set the updated value of an object to V
--spec update_value(riakc_obj(), value(), content_type()) -> riakc_obj().
+-spec update_value(riakc_obj(), value(), content_type()|binary()) -> riakc_obj().
 update_value(Object=#riakc_obj{}, V, CT) -> 
     O1 = update_content_type(Object, CT),
     O1#riakc_obj{updatevalue=V}.


### PR DESCRIPTION
This allows a binary to be passed in for the content type parameter on `riak_obj:update_value/3`, making it take the same values for content type as `riak_obj:update_content_type/2`. This should be completely safe, since `update_value/3` calls `update_content_type/2` under the hood.