### PR TITLE
Improve dialyzer types and checking

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -2272,8 +2272,8 @@ start_tls(State=#state{sock=Sock}) ->
     end.
 
 start_auth(State=#state{credentials={User,Pass}, sock=Sock}) ->
-    ok = ssl:send(Sock, riak_pb_codec:encode(#rpbauthreq{user=User,
-                                                         password=Pass})),
+    ok = ssl:send(Sock, riak_pb_codec:encode(#rpbauthreq{user=iolist_to_binary(User),
+                                                         password=iolist_to_binary(Pass)})),
     receive
         {ssl_error, Sock, Reason} ->
             {error, Reason};

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -182,6 +182,10 @@
 
 -export_type([address/0, portnum/0]).
 
+%% Disable "The pattern 'undefined' can never match the type [binary()]"
+%% warnings in process_response/3:
+-dialyzer({no_match, process_response/3}).
+
 %% @private Like `gen_server:call/3', but with the timeout hardcoded
 %% to `infinity'.
 call_infinity(Pid, Msg) ->

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -127,6 +127,8 @@
                   {end_key, binary()} |
                   {end_incl, boolean()}.
 -type cs_opts() :: [cs_opt()].
+-type registered_name() :: atom().
+-type server_ref() :: registered_name() | pid().
 
 %% Which client operation the default timeout is being requested
 %% for. `timeout' is the global default timeout. Any of these defaults
@@ -209,7 +211,7 @@ start(Address, Port, Options) when is_list(Options) ->
     gen_server:start(?MODULE, [Address, Port, Options], []).
 
 %% @doc Disconnect the socket and stop the process.
--spec stop(pid()) -> ok.
+-spec stop(server_ref()) -> ok.
 stop(Pid) ->
     call_infinity(Pid, stop).
 
@@ -218,14 +220,14 @@ stop(Pid) ->
 %%      make sure the server is there, then enable queue_if_disconnected).
 %% @equiv set_options(Pid, Options, infinity)
 %% @see start_link/3
--spec set_options(pid(), client_options()) -> ok.
+-spec set_options(server_ref(), client_options()) -> ok.
 set_options(Pid, Options) ->
     call_infinity(Pid, {set_options, Options}).
 
 %% @doc Like set_options/2, but with a gen_server timeout.
 %% @see start_link/3
 %% @deprecated
--spec set_options(pid(), client_options(), timeout()) -> ok.
+-spec set_options(server_ref(), client_options(), timeout()) -> ok.
 set_options(Pid, Options, Timeout) ->
     gen_server:call(Pid, {set_options, Options}, Timeout).
 
@@ -233,7 +235,7 @@ set_options(Pid, Options, Timeout) ->
 %% connected, or false and a list of connection failures and frequencies if
 %% disconnected.
 %% @equiv is_connected(Pid, infinity)
--spec is_connected(pid()) -> true | {false, [connection_failure()]}.
+-spec is_connected(server_ref()) -> true | {false, [connection_failure()]}.
 is_connected(Pid) ->
     call_infinity(Pid, is_connected).
 
@@ -242,40 +244,40 @@ is_connected(Pid) ->
 %% and a list of connection failures and frequencies if disconnected.
 %% @see is_connected/1
 %% @deprecated
--spec is_connected(pid(), timeout()) -> true | {false, [connection_failure()]}.
+-spec is_connected(server_ref(), timeout()) -> true | {false, [connection_failure()]}.
 is_connected(Pid, Timeout) ->
     gen_server:call(Pid, is_connected, Timeout).
 
 %% @doc Ping the server
 %% @equiv ping(Pid, default_timeout(ping_timeout))
--spec ping(pid()) -> pong.
+-spec ping(server_ref()) -> pong.
 ping(Pid) ->
     call_infinity(Pid, {req, rpbpingreq, default_timeout(ping_timeout)}).
 
 %% @doc Ping the server specifying timeout
--spec ping(pid(), timeout()) -> pong.
+-spec ping(server_ref(), timeout()) -> pong.
 ping(Pid, Timeout) ->
     call_infinity(Pid, {req, rpbpingreq, Timeout}).
 
 %% @doc Get the client id for this connection
 %% @equiv get_client_id(Pid, default_timeout(get_client_id_timeout))
--spec get_client_id(pid()) -> {ok, client_id()} | {error, term()}.
+-spec get_client_id(server_ref()) -> {ok, client_id()} | {error, term()}.
 get_client_id(Pid) ->
     get_client_id(Pid, default_timeout(get_client_id_timeout)).
 
 %% @doc Get the client id for this connection specifying timeout
--spec get_client_id(pid(), timeout()) -> {ok, client_id()} | {error, term()}.
+-spec get_client_id(server_ref(), timeout()) -> {ok, client_id()} | {error, term()}.
 get_client_id(Pid, Timeout) ->
     call_infinity(Pid, {req, rpbgetclientidreq, Timeout}).
 
 %% @doc Set the client id for this connection
 %% @equiv set_client_id(Pid, ClientId, default_timeout(set_client_id_timeout))
--spec set_client_id(pid(), client_id()) -> {ok, client_id()} | {error, term()}.
+-spec set_client_id(server_ref(), client_id()) -> {ok, client_id()} | {error, term()}.
 set_client_id(Pid, ClientId) ->
     set_client_id(Pid, ClientId, default_timeout(set_client_id_timeout)).
 
 %% @doc Set the client id for this connection specifying timeout
--spec set_client_id(pid(), client_id(), timeout()) -> {ok, client_id()} | {error, term()}.
+-spec set_client_id(server_ref(), client_id(), timeout()) -> {ok, client_id()} | {error, term()}.
 set_client_id(Pid, ClientId, Timeout) ->
     call_infinity(Pid,
                   {req, #rpbsetclientidreq{client_id = ClientId},
@@ -283,26 +285,26 @@ set_client_id(Pid, ClientId, Timeout) ->
 
 %% @doc Get the server information for this connection
 %% @equiv get_server_info(Pid, default_timeout(get_server_info_timeout))
--spec get_server_info(pid()) -> {ok, server_info()} | {error, term()}.
+-spec get_server_info(server_ref()) -> {ok, server_info()} | {error, term()}.
 get_server_info(Pid) ->
     get_server_info(Pid, default_timeout(get_server_info_timeout)).
 
 %% @doc Get the server information for this connection specifying timeout
--spec get_server_info(pid(), timeout()) -> {ok, server_info()} | {error, term()}.
+-spec get_server_info(server_ref(), timeout()) -> {ok, server_info()} | {error, term()}.
 get_server_info(Pid, Timeout) ->
     call_infinity(Pid, {req, rpbgetserverinforeq, Timeout}).
 
 %% @doc Get bucket/key from the server.
 %%      Will return {error, notfound} if the key is not on the server.
 %% @equiv get(Pid, Bucket, Key, [], default_timeout(get_timeout))
--spec get(pid(), bucket() | bucket_and_type(), key()) -> {ok, riakc_obj()} | {error, term()}.
+-spec get(server_ref(), bucket() | bucket_and_type(), key()) -> {ok, riakc_obj()} | {error, term()}.
 get(Pid, Bucket, Key) ->
     get(Pid, Bucket, Key, [], default_timeout(get_timeout)).
 
 %% @doc Get bucket/key from the server specifying timeout.
 %%      Will return {error, notfound} if the key is not on the server.
 %% @equiv get(Pid, Bucket, Key, Options, Timeout)
--spec get(pid(), bucket() | bucket_and_type(), key(), TimeoutOrOptions::timeout() |  get_options()) ->
+-spec get(server_ref(), bucket() | bucket_and_type(), key(), TimeoutOrOptions::timeout() |  get_options()) ->
                  {ok, riakc_obj()} | {error, term()} | unchanged.
 get(Pid, Bucket, Key, Timeout) when is_integer(Timeout); Timeout =:= infinity ->
     get(Pid, Bucket, Key, [], Timeout);
@@ -313,7 +315,7 @@ get(Pid, Bucket, Key, Options) ->
 %%      <code>unchanged</code> will be returned when the
 %%      <code>{if_modified, Vclock}</code> option is specified and the
 %%      object is unchanged.
--spec get(pid(), bucket() | bucket_and_type(), key(), get_options(), timeout()) ->
+-spec get(server_ref(), bucket() | bucket_and_type(), key(), get_options(), timeout()) ->
                  {ok, riakc_obj()} | {error, term()} | unchanged.
 get(Pid, Bucket, Key, Options, Timeout) ->
     {T, B} = maybe_bucket_type(Bucket),
@@ -323,7 +325,7 @@ get(Pid, Bucket, Key, Options, Timeout) ->
 %% @doc Put the metadata/value in the object under bucket/key
 %% @equiv put(Pid, Obj, [])
 %% @see put/4
--spec put(pid(), riakc_obj()) ->
+-spec put(server_ref(), riakc_obj()) ->
                  ok | {ok, riakc_obj()} | {ok, key()} | {error, term()}.
 put(Pid, Obj) ->
     put(Pid, Obj, []).
@@ -331,7 +333,7 @@ put(Pid, Obj) ->
 %% @doc Put the metadata/value in the object under bucket/key with options or timeout.
 %% @equiv put(Pid, Obj, Options, Timeout)
 %% @see put/4
--spec put(pid(), riakc_obj(), TimeoutOrOptions::timeout() | put_options()) ->
+-spec put(server_ref(), riakc_obj(), TimeoutOrOptions::timeout() | put_options()) ->
                  ok | {ok, riakc_obj()} |  riakc_obj() | {ok, key()} | {error, term()}.
 put(Pid, Obj, Timeout) when is_integer(Timeout); Timeout =:= infinity ->
     put(Pid, Obj, [], Timeout);
@@ -349,7 +351,7 @@ put(Pid, Obj, Options) ->
 %%      `return_body' was specified.
 %% @throws siblings
 %% @end
--spec put(pid(), riakc_obj(), put_options(), timeout()) ->
+-spec put(server_ref(), riakc_obj(), put_options(), timeout()) ->
                  ok | {ok, riakc_obj()} | riakc_obj() | {ok, key()} | {error, term()}.
 put(Pid, Obj, Options, Timeout) ->
     Content = riak_pb_kv_codec:encode_content({riakc_obj:get_update_metadata(Obj),
@@ -364,13 +366,13 @@ put(Pid, Obj, Options, Timeout) ->
 
 %% @doc Delete the key/value
 %% @equiv delete(Pid, Bucket, Key, [])
--spec delete(pid(), bucket() | bucket_and_type(), key()) -> ok | {error, term()}.
+-spec delete(server_ref(), bucket() | bucket_and_type(), key()) -> ok | {error, term()}.
 delete(Pid, Bucket, Key) ->
     delete(Pid, Bucket, Key, []).
 
 %% @doc Delete the key/value specifying timeout or options. <em>Note that the rw quorum is deprecated, use r and w.</em>
 %% @equiv delete(Pid, Bucket, Key, Options, Timeout)
--spec delete(pid(), bucket() | bucket_and_type(), key(), TimeoutOrOptions::timeout() | delete_options()) ->
+-spec delete(server_ref(), bucket() | bucket_and_type(), key(), TimeoutOrOptions::timeout() | delete_options()) ->
                     ok | {error, term()}.
 delete(Pid, Bucket, Key, Timeout) when is_integer(Timeout); Timeout =:= infinity ->
     delete(Pid, Bucket, Key, [], Timeout);
@@ -378,7 +380,7 @@ delete(Pid, Bucket, Key, Options) ->
     delete(Pid, Bucket, Key, Options, default_timeout(delete_timeout)).
 
 %% @doc Delete the key/value with options and timeout. <em>Note that the rw quorum is deprecated, use r and w.</em>
--spec delete(pid(), bucket() | bucket_and_type(), key(), delete_options(), timeout()) -> ok | {error, term()}.
+-spec delete(server_ref(), bucket() | bucket_and_type(), key(), delete_options(), timeout()) -> ok | {error, term()}.
 delete(Pid, Bucket, Key, Options, Timeout) ->
     {T, B} = maybe_bucket_type(Bucket),
     Req = delete_options(Options, #rpbdelreq{type = T, bucket = B, key = Key}),
@@ -387,13 +389,13 @@ delete(Pid, Bucket, Key, Options, Timeout) ->
 
 %% @doc Delete the object at Bucket/Key, giving the vector clock.
 %% @equiv delete_vclock(Pid, Bucket, Key, VClock, [])
--spec delete_vclock(pid(), bucket() | bucket_and_type(), key(), riakc_obj:vclock()) -> ok | {error, term()}.
+-spec delete_vclock(server_ref(), bucket() | bucket_and_type(), key(), riakc_obj:vclock()) -> ok | {error, term()}.
 delete_vclock(Pid, Bucket, Key, VClock) ->
     delete_vclock(Pid, Bucket, Key, VClock, []).
 
 %% @doc Delete the object at Bucket/Key, specifying timeout or options and giving the vector clock.
 %% @equiv delete_vclock(Pid, Bucket, Key, VClock, Options, Timeout)
--spec delete_vclock(pid(), bucket() | bucket_and_type(), key(), riakc_obj:vclock(), TimeoutOrOptions::timeout() | delete_options()) ->
+-spec delete_vclock(server_ref(), bucket() | bucket_and_type(), key(), riakc_obj:vclock(), TimeoutOrOptions::timeout() | delete_options()) ->
                            ok | {error, term()}.
 delete_vclock(Pid, Bucket, Key, VClock, Timeout) when is_integer(Timeout); Timeout =:= infinity ->
     delete_vclock(Pid, Bucket, Key, VClock, [], Timeout);
@@ -404,7 +406,7 @@ delete_vclock(Pid, Bucket, Key, VClock, Options) ->
 %% vector clock. This form of delete ensures that subsequent get and
 %% put requests will be correctly ordered with the delete.
 %% @see delete_obj/4
--spec delete_vclock(pid(), bucket() | bucket_and_type(), key(), riakc_obj:vclock(), delete_options(), timeout()) ->
+-spec delete_vclock(server_ref(), bucket() | bucket_and_type(), key(), riakc_obj:vclock(), delete_options(), timeout()) ->
                            ok | {error, term()}.
 delete_vclock(Pid, Bucket, Key, VClock, Options, Timeout) ->
     {T, B} = maybe_bucket_type(Bucket),
@@ -416,7 +418,7 @@ delete_vclock(Pid, Bucket, Key, VClock, Options, Timeout) ->
 %% @doc Delete the riak object.
 %% @equiv delete_vclock(Pid, riakc_obj:bucket(Obj), riakc_obj:key(Obj), riakc_obj:vclock(Obj))
 %% @see delete_vclock/6
--spec delete_obj(pid(), riakc_obj()) -> ok | {error, term()}.
+-spec delete_obj(server_ref(), riakc_obj()) -> ok | {error, term()}.
 delete_obj(Pid, Obj) ->
     delete_vclock(Pid, riakc_obj:bucket(Obj), riakc_obj:key(Obj),
         riakc_obj:vclock(Obj), [], default_timeout(delete_timeout)).
@@ -424,7 +426,7 @@ delete_obj(Pid, Obj) ->
 %% @doc Delete the riak object with options.
 %% @equiv delete_vclock(Pid, riakc_obj:bucket(Obj), riakc_obj:key(Obj), riakc_obj:vclock(Obj), Options)
 %% @see delete_vclock/6
--spec delete_obj(pid(), riakc_obj(), delete_options()) -> ok | {error, term()}.
+-spec delete_obj(server_ref(), riakc_obj(), delete_options()) -> ok | {error, term()}.
 delete_obj(Pid, Obj, Options) ->
     delete_vclock(Pid, riakc_obj:bucket(Obj), riakc_obj:key(Obj),
         riakc_obj:vclock(Obj), Options, default_timeout(delete_timeout)).
@@ -432,7 +434,7 @@ delete_obj(Pid, Obj, Options) ->
 %% @doc Delete the riak object with options and timeout.
 %% @equiv delete_vclock(Pid, riakc_obj:bucket(Obj), riakc_obj:key(Obj), riakc_obj:vclock(Obj), Options, Timeout)
 %% @see delete_vclock/6
--spec delete_obj(pid(), riakc_obj(), delete_options(), timeout()) -> ok | {error, term()}.
+-spec delete_obj(server_ref(), riakc_obj(), delete_options(), timeout()) -> ok | {error, term()}.
 delete_obj(Pid, Obj, Options, Timeout) ->
     delete_vclock(Pid, riakc_obj:bucket(Obj), riakc_obj:key(Obj),
         riakc_obj:vclock(Obj), Options, Timeout).
@@ -440,13 +442,13 @@ delete_obj(Pid, Obj, Options, Timeout) ->
 %% @doc List all buckets on the server in the "default" bucket type.
 %% <em>This is a potentially expensive operation and should not be used in production.</em>
 %% @equiv list_buckets(Pid, default_timeout(list_buckets_timeout))
--spec list_buckets(pid()) -> {ok, [bucket()]} | {error, term()}.
+-spec list_buckets(server_ref()) -> {ok, [bucket()]} | {error, term()}.
 list_buckets(Pid) ->
     list_buckets(Pid, <<"default">>, []).
 
 %% @doc List all buckets in a bucket type, specifying server-side timeout.
 %% <em>This is a potentially expensive operation and should not be used in production.</em>
--spec list_buckets(pid(), timeout()|list()|binary()) -> {ok, [bucket()]} |
+-spec list_buckets(server_ref(), timeout()|list()|binary()) -> {ok, [bucket()]} |
                                                    {error, term()}.
 list_buckets(Pid, Type) when is_binary(Type) ->
     list_buckets(Pid, Type, []);
@@ -509,7 +511,7 @@ do_legacy_list_buckets(true, Pid, Options) ->
 %% @doc List all keys in a bucket
 %% <em>This is a potentially expensive operation and should not be used in production.</em>
 %% @equiv list_keys(Pid, Bucket, default_timeout(list_keys_timeout))
--spec list_keys(pid(), bucket() | bucket_and_type()) -> {ok, [key()]} | {error, term()}.
+-spec list_keys(server_ref(), bucket() | bucket_and_type()) -> {ok, [key()]} | {error, term()}.
 list_keys(Pid, Bucket) ->
     list_keys(Pid, Bucket, []).
 
@@ -517,7 +519,7 @@ list_keys(Pid, Bucket) ->
 %% implemented using {@link stream_list_keys/3} and then waiting for
 %% the results to complete streaming.
 %% <em>This is a potentially expensive operation and should not be used in production.</em>
--spec list_keys(pid(), bucket() | bucket_and_type(), list()|timeout()) -> {ok, [key()]} |
+-spec list_keys(server_ref(), bucket() | bucket_and_type(), list()|timeout()) -> {ok, [key()]} |
                                                                           {error, term()}.
 list_keys(Pid, Bucket, infinity) ->
     list_keys(Pid, Bucket, [{timeout, undefined}]);
@@ -537,7 +539,7 @@ list_keys(Pid, Bucket, Options) ->
 %%        {ReqId::req_id(), done}'''
 %% <em>This is a potentially expensive operation and should not be used in production.</em>
 %% @equiv stream_list_keys(Pid, Bucket, default_timeout(stream_list_keys_timeout))
--spec stream_list_keys(pid(), bucket()) -> {ok, req_id()} | {error, term()}.
+-spec stream_list_keys(server_ref(), bucket()) -> {ok, req_id()} | {error, term()}.
 stream_list_keys(Pid, Bucket) ->
     stream_list_keys(Pid, Bucket, []).
 
@@ -548,7 +550,7 @@ stream_list_keys(Pid, Bucket) ->
 %%        {ReqId::req_id(), done}'''
 %% <em>This is a potentially expensive operation and should not be used in production.</em>
 %% @equiv stream_list_keys(Pid, Bucket, Timeout, default_timeout(stream_list_keys_call_timeout))
--spec stream_list_keys(pid(), bucket() | bucket_and_type(), integer()|list()) ->
+-spec stream_list_keys(server_ref(), bucket() | bucket_and_type(), integer()|list()) ->
                               {ok, req_id()} |
                               {error, term()}.
 stream_list_keys(Pid, Bucket, infinity) ->
@@ -575,19 +577,19 @@ do_stream_list_keys(true, Pid, Bucket, Options) ->
 
 %% @doc Get bucket properties.
 %% @equiv get_bucket(Pid, Bucket, default_timeout(get_bucket_timeout))
--spec get_bucket(pid(), bucket() | bucket_and_type()) -> {ok, bucket_props()} | {error, term()}.
+-spec get_bucket(server_ref(), bucket() | bucket_and_type()) -> {ok, bucket_props()} | {error, term()}.
 get_bucket(Pid, Bucket) ->
     get_bucket(Pid, Bucket, default_timeout(get_bucket_timeout)).
 
 %% @doc Get bucket properties specifying a server side timeout.
 %% @equiv get_bucket(Pid, Bucket, Timeout, default_timeout(get_bucket_call_timeout))
--spec get_bucket(pid(), bucket() | bucket_and_type(), timeout()) -> {ok, bucket_props()} | {error, term()}.
+-spec get_bucket(server_ref(), bucket() | bucket_and_type(), timeout()) -> {ok, bucket_props()} | {error, term()}.
 get_bucket(Pid, Bucket, Timeout) ->
     get_bucket(Pid, Bucket, Timeout, default_timeout(get_bucket_call_timeout)).
 
 %% @doc Get bucket properties specifying a server side and local call timeout.
 %% @deprecated because `CallTimeout' is ignored
--spec get_bucket(pid(), bucket() | bucket_and_type(), timeout(), timeout()) -> {ok, bucket_props()} |
+-spec get_bucket(server_ref(), bucket() | bucket_and_type(), timeout(), timeout()) -> {ok, bucket_props()} |
                                                            {error, term()}.
 get_bucket(Pid, Bucket, Timeout, _CallTimeout) ->
     {T, B} = maybe_bucket_type(Bucket),
@@ -603,20 +605,20 @@ get_bucket_type(Pid, BucketType, Timeout) ->
 
 %% @doc Set bucket properties.
 %% @equiv set_bucket(Pid, Bucket, BucketProps, default_timeout(set_bucket_timeout))
--spec set_bucket(pid(), bucket() | bucket_and_type(), bucket_props()) -> ok | {error, term()}.
+-spec set_bucket(server_ref(), bucket() | bucket_and_type(), bucket_props()) -> ok | {error, term()}.
 set_bucket(Pid, Bucket, BucketProps) ->
     set_bucket(Pid, Bucket, BucketProps, default_timeout(set_bucket_timeout)).
 
 %% @doc Set bucket properties specifying a server side timeout.
 %% @equiv set_bucket(Pid, Bucket, BucketProps, Timeout, default_timeout(set_bucket_call_timeout))
--spec set_bucket(pid(), bucket() | bucket_and_type(), bucket_props(), timeout()) -> ok | {error, term()}.
+-spec set_bucket(server_ref(), bucket() | bucket_and_type(), bucket_props(), timeout()) -> ok | {error, term()}.
 set_bucket(Pid, Bucket, BucketProps, Timeout) ->
     set_bucket(Pid, Bucket, BucketProps, Timeout,
                default_timeout(set_bucket_call_timeout)).
 
 %% @doc Set bucket properties specifying a server side and local call timeout.
 %% @deprecated because `CallTimeout' is ignored
--spec set_bucket(pid(), bucket() | bucket_and_type(), bucket_props(), timeout(), timeout()) -> ok | {error, term()}.
+-spec set_bucket(server_ref(), bucket() | bucket_and_type(), bucket_props(), timeout(), timeout()) -> ok | {error, term()}.
 set_bucket(Pid, Bucket, BucketProps, Timeout, _CallTimeout) ->
     PbProps = riak_pb_codec:encode_bucket_props(BucketProps),
     {T, B} = maybe_bucket_type(Bucket),
@@ -633,19 +635,19 @@ set_bucket_type(Pid, BucketType, BucketProps, Timeout) ->
 
 %% @doc Reset bucket properties back to the defaults.
 %% @equiv reset_bucket(Pid, Bucket, default_timeout(reset_bucket_timeout), default_timeout(reset_bucket_call_timeout))
--spec reset_bucket(pid(), bucket() | bucket_and_type()) -> ok | {error, term()}.
+-spec reset_bucket(server_ref(), bucket() | bucket_and_type()) -> ok | {error, term()}.
 reset_bucket(Pid, Bucket) ->
     reset_bucket(Pid, Bucket, default_timeout(reset_bucket_timeout), default_timeout(reset_bucket_call_timeout)).
 
 %% @doc Reset bucket properties back to the defaults.
 %% @equiv reset_bucket(Pid, Bucket, Timeout, default_timeout(reset_bucket_call_timeout))
--spec reset_bucket(pid(), bucket() | bucket_and_type(), timeout()) -> ok | {error, term()}.
+-spec reset_bucket(server_ref(), bucket() | bucket_and_type(), timeout()) -> ok | {error, term()}.
 reset_bucket(Pid, Bucket, Timeout) ->
     reset_bucket(Pid, Bucket, Timeout, default_timeout(reset_bucket_call_timeout)).
 
 %% @doc Reset bucket properties back to the defaults.
 %% @deprecated because `CallTimeout' is ignored
--spec reset_bucket(pid(), bucket() | bucket_and_type(), timeout(), timeout()) -> ok | {error, term()}.
+-spec reset_bucket(server_ref(), bucket() | bucket_and_type(), timeout(), timeout()) -> ok | {error, term()}.
 reset_bucket(Pid, Bucket, Timeout, _CallTimeout) ->
     {T, B} = maybe_bucket_type(Bucket),
     Req = #rpbresetbucketreq{type = T, bucket = B},
@@ -654,7 +656,7 @@ reset_bucket(Pid, Bucket, Timeout, _CallTimeout) ->
 %% @doc Perform a MapReduce job across the cluster.
 %%      See the MapReduce documentation for explanation of behavior.
 %% @equiv mapred(Inputs, Query, default_timeout(mapred))
--spec mapred(pid(), mapred_inputs(), [mapred_queryterm()]) ->
+-spec mapred(server_ref(), mapred_inputs(), [mapred_queryterm()]) ->
                     {ok, mapred_result()} |
                     {error, {badqterm, mapred_queryterm()}} |
                     {error, timeout} |
@@ -665,7 +667,7 @@ mapred(Pid, Inputs, Query) ->
 %% @doc Perform a MapReduce job across the cluster with a job timeout.
 %%      See the MapReduce documentation for explanation of behavior.
 %% @equiv mapred(Pid, Inputs, Query, Timeout, default_timeout(mapred_call_timeout))
--spec mapred(pid(), mapred_inputs(), [mapred_queryterm()], timeout()) ->
+-spec mapred(server_ref(), mapred_inputs(), [mapred_queryterm()], timeout()) ->
                     {ok, mapred_result()} |
                     {error, {badqterm, mapred_queryterm()}} |
                     {error, timeout} |
@@ -678,7 +680,7 @@ mapred(Pid, Inputs, Query, Timeout) ->
 %%      explanation of behavior. This is implemented by using
 %%      <code>mapred_stream/6</code> and then waiting for all results.
 %% @see mapred_stream/6
--spec mapred(pid(), mapred_inputs(), [mapred_queryterm()], timeout(), timeout()) ->
+-spec mapred(server_ref(), mapred_inputs(), [mapred_queryterm()], timeout(), timeout()) ->
                     {ok, mapred_result()} |
                     {error, {badqterm, mapred_queryterm()}} |
                     {error, timeout} |
@@ -698,7 +700,7 @@ mapred(Pid, Inputs, Query, Timeout, CallTimeout) ->
 %% ```  {ReqId::req_id(), {mapred, Phase::non_neg_integer(), mapred_result()}}
 %%      {ReqId::req_id(), done}'''
 %% @equiv mapred_stream(ConnectionPid, Inputs, Query, ClientPid, default_timeout(mapred_stream_timeout))
--spec mapred_stream(ConnectionPid::pid(),Inputs::mapred_inputs(),Query::[mapred_queryterm()], ClientPid::pid()) ->
+-spec mapred_stream(ConnectionPid::server_ref(),Inputs::mapred_inputs(),Query::[mapred_queryterm()], ClientPid::pid()) ->
                            {ok, req_id()} |
                            {error, {badqterm, mapred_queryterm()}} |
                            {error, timeout} |
@@ -713,7 +715,7 @@ mapred_stream(Pid, Inputs, Query, ClientPid) ->
 %% ```  {ReqId::req_id(), {mapred, Phase::non_neg_integer(), mapred_result()}}
 %%      {ReqId::req_id(), done}'''
 %% @equiv mapred_stream(ConnectionPid, Inputs, Query, ClientPid, Timeout, default_timeout(mapred_stream_call_timeout))
--spec mapred_stream(ConnectionPid::pid(),Inputs::mapred_inputs(),Query::[mapred_queryterm()], ClientPid::pid(), Timeout::timeout()) ->
+-spec mapred_stream(ConnectionPid::server_ref(),Inputs::mapred_inputs(),Query::[mapred_queryterm()], ClientPid::pid(), Timeout::timeout()) ->
                            {ok, req_id()} |
                            {error, {badqterm, mapred_queryterm()}} |
                            {error, timeout} |
@@ -729,7 +731,7 @@ mapred_stream(Pid, Inputs, Query, ClientPid, Timeout) ->
 %% ```  {ReqId::req_id(), {mapred, Phase::non_neg_integer(), mapred_result()}}
 %%      {ReqId::req_id(), done}'''
 %% @deprecated because `CallTimeout' is ignored
--spec mapred_stream(ConnectionPid::pid(),Inputs::mapred_inputs(),
+-spec mapred_stream(ConnectionPid::server_ref(),Inputs::mapred_inputs(),
                     Query::[mapred_queryterm()], ClientPid::pid(),
                     Timeout::timeout(), CallTimeout::timeout()) ->
                            {ok, req_id()} |
@@ -772,7 +774,7 @@ do_mapred_stream(_AllowListing, Pid, Inputs, Query, ClientPid, Timeout) ->
 %%      See the MapReduce documentation for explanation of behavior.
 %% <em>This uses list_keys under the hood and so is potentially an expensive operation that should not be used in production.</em>
 %% @equiv mapred_bucket(Pid, Bucket, Query, default_timeout(mapred_bucket_timeout))
--spec mapred_bucket(Pid::pid(), Bucket::bucket(), Query::[mapred_queryterm()]) ->
+-spec mapred_bucket(Pid::server_ref(), Bucket::bucket(), Query::[mapred_queryterm()]) ->
                            {ok, mapred_result()} |
                            {error, {badqterm, mapred_queryterm()}} |
                            {error, timeout} |
@@ -785,7 +787,7 @@ mapred_bucket(Pid, Bucket, Query) ->
 %%      See the MapReduce documentation for explanation of behavior.
 %% <em>This uses list_keys under the hood and so is potentially an expensive operation that should not be used in production.</em>
 %% @equiv mapred_bucket(Pid, Bucket, Query, Timeout, default_timeout(mapred_bucket_call_timeout))
--spec mapred_bucket(Pid::pid(), Bucket::bucket(), Query::[mapred_queryterm()], Timeout::timeout()) ->
+-spec mapred_bucket(Pid::server_ref(), Bucket::bucket(), Query::[mapred_queryterm()], Timeout::timeout()) ->
                            {ok, mapred_result()} |
                            {error, {badqterm, mapred_queryterm()}} |
                            {error, timeout} |
@@ -797,7 +799,7 @@ mapred_bucket(Pid, Bucket, Query, Timeout) ->
 %%      across the cluster and local call timeout.
 %%      See the MapReduce documentation for explanation of behavior.
 %% <em>This uses list_keys under the hood and so is potentially an expensive operation that should not be used in production.</em>
--spec mapred_bucket(Pid::pid(), Bucket::bucket(), Query::[mapred_queryterm()],
+-spec mapred_bucket(Pid::server_ref(), Bucket::bucket(), Query::[mapred_queryterm()],
                     Timeout::timeout(), CallTimeout::timeout()) ->
                            {ok, mapred_result()} |
                            {error, {badqterm, mapred_queryterm()}} |
@@ -819,7 +821,7 @@ mapred_bucket(Pid, Bucket, Query, Timeout, CallTimeout) ->
 %% ```  {ReqId::req_id(), {mapred, Phase::non_neg_integer(), mapred_result()}}
 %%      {ReqId::req_id(), done}'''
 %% @equiv     mapred_bucket_stream(Pid, Bucket, Query, ClientPid, Timeout, default_timeout(mapred_bucket_stream_call_timeout))
--spec mapred_bucket_stream(ConnectionPid::pid(), bucket(), [mapred_queryterm()], ClientPid::pid(), timeout()) ->
+-spec mapred_bucket_stream(ConnectionPid::server_ref(), bucket(), [mapred_queryterm()], ClientPid::pid(), timeout()) ->
                                   {ok, req_id()} |
                                   {error, term()}.
 mapred_bucket_stream(Pid, Bucket, Query, ClientPid, Timeout) ->
@@ -834,7 +836,7 @@ mapred_bucket_stream(Pid, Bucket, Query, ClientPid, Timeout) ->
 %% ```  {ReqId::req_id(), {mapred, Phase::non_neg_integer(), mapred_result()}}
 %%      {ReqId::req_id(), done}'''
 %% @deprecated because `CallTimeout' is ignored
--spec mapred_bucket_stream(ConnectionPid::pid(), bucket(), [mapred_queryterm()], ClientPid::pid(), timeout(), timeout()) ->
+-spec mapred_bucket_stream(ConnectionPid::server_ref(), bucket(), [mapred_queryterm()], ClientPid::pid(), timeout(), timeout()) ->
                                   {ok, req_id()} | {error, term()}.
 mapred_bucket_stream(Pid, Bucket, Query, ClientPid, Timeout, _CallTimeout) ->
     MapRed = [{'inputs', Bucket},
@@ -845,14 +847,14 @@ mapred_bucket_stream(Pid, Bucket, Query, ClientPid, Timeout, _CallTimeout) ->
 
 %% @doc Execute a search query. This command will return an error
 %%      unless executed against a Riak Search cluster.
--spec search(pid(), binary(), binary()) ->
+-spec search(server_ref(), binary(), binary()) ->
                     {ok, search_result()} | {error, term()}.
 search(Pid, Index, SearchQuery) ->
     search(Pid, Index, SearchQuery, []).
 
 %% @doc Execute a search query. This command will return an error
 %%      unless executed against a Riak Search cluster.
--spec search(pid(), binary(), binary(), search_options()) ->
+-spec search(server_ref(), binary(), binary(), search_options()) ->
                     {ok, search_result()} | {error, term()}.
 search(Pid, Index, SearchQuery, Options) ->
     Timeout = default_timeout(search_timeout),
@@ -860,7 +862,7 @@ search(Pid, Index, SearchQuery, Options) ->
 
 %% @doc Execute a search query. This command will return an error
 %%      unless executed against a Riak Search cluster.
--spec search(pid(), binary(), binary(), search_options(), timeout()) ->
+-spec search(server_ref(), binary(), binary(), search_options(), timeout()) ->
                     {ok, search_result()} | {error, term()}.
 search(Pid, Index, SearchQuery, Options, Timeout) ->
     CallTimeout = default_timeout(search_call_timeout),
@@ -869,25 +871,25 @@ search(Pid, Index, SearchQuery, Options, Timeout) ->
 %% @doc Execute a search query. This command will return an error
 %%      unless executed against a Riak Search cluster.
 %% @deprecated because `CallTimeout' is ignored
--spec search(pid(), binary(), binary(), search_options(), timeout(), timeout()) ->
+-spec search(server_ref(), binary(), binary(), search_options(), timeout(), timeout()) ->
                     {ok, search_result()} | {error, term()}.
 search(Pid, Index, SearchQuery, Options, Timeout, _CallTimeout) ->
     Req = search_options(Options, #rpbsearchqueryreq{q = SearchQuery, index = Index}),
     call_infinity(Pid, {req, Req, Timeout}).
 
--spec get_search_schema(pid(), binary(), search_admin_opts()) ->
+-spec get_search_schema(server_ref(), binary(), search_admin_opts()) ->
                     {ok, search_schema()} | {error, term()}.
 get_search_schema(Pid, SchemaName, Opts) ->
     Timeout = proplists:get_value(timeout, Opts, default_timeout(search_timeout)),
     Req = #rpbyokozunaschemagetreq{ name = SchemaName },
     call_infinity(Pid, {req, Req, Timeout}).
 
--spec get_search_schema(pid(), binary()) ->
+-spec get_search_schema(server_ref(), binary()) ->
                     {ok, search_schema()} | {error, term()}.
 get_search_schema(Pid, SchemaName) ->
     get_search_schema(Pid, SchemaName, []).
 
--spec get_search_index(pid(), binary(), search_admin_opts()) ->
+-spec get_search_index(server_ref(), binary(), search_admin_opts()) ->
                     {ok, search_index()} | {error, term()}.
 get_search_index(Pid, Index, Opts) ->
     Timeout = proplists:get_value(timeout, Opts, default_timeout(search_timeout)),
@@ -901,30 +903,30 @@ get_search_index(Pid, Index, Opts) ->
         X -> X
     end.
 
--spec get_search_index(pid(), binary()) ->
+-spec get_search_index(server_ref(), binary()) ->
                     {ok, search_index()} | {error, term()}.
 get_search_index(Pid, Index) ->
     get_search_index(Pid, Index, []).
 
--spec list_search_indexes(pid(), search_admin_opts()) ->
+-spec list_search_indexes(server_ref(), search_admin_opts()) ->
                     {ok, [search_index()]} | {error, term()}.
 list_search_indexes(Pid, Opts) ->
     Timeout = proplists:get_value(timeout, Opts, default_timeout(search_timeout)),
     call_infinity(Pid, {req, #rpbyokozunaindexgetreq{}, Timeout}).
 
--spec list_search_indexes(pid()) ->
+-spec list_search_indexes(server_ref()) ->
                     {ok, [search_index()]} | {error, term()}.
 list_search_indexes(Pid) ->
     list_search_indexes(Pid, []).
 
 %% @doc Create a schema, which is a required component of an index.
--spec create_search_schema(pid(), binary(), binary()) ->
+-spec create_search_schema(server_ref(), binary(), binary()) ->
                     ok | {error, term()}.
 create_search_schema(Pid, SchemaName, Content) ->
     create_search_schema(Pid, SchemaName, Content, []).
 
 %% @doc Create a schema, which is a required component of an index.
--spec create_search_schema(pid(), binary(), binary(), search_admin_opts()) ->
+-spec create_search_schema(server_ref(), binary(), binary(), search_admin_opts()) ->
                     ok | {error, term()}.
 create_search_schema(Pid, SchemaName, Content, Opts) ->
     Timeout = proplists:get_value(timeout, Opts, default_timeout(search_timeout)),
@@ -934,12 +936,12 @@ create_search_schema(Pid, SchemaName, Content, Opts) ->
     call_infinity(Pid, {req, Req, Timeout}).
 
 %% @doc Create a search index.
--spec create_search_index(pid(), binary()) ->
+-spec create_search_index(server_ref(), binary()) ->
                     ok | {error, term()}.
 create_search_index(Pid, Index) ->
     create_search_index(Pid, Index, <<>>, []).
 
--spec create_search_index(pid(), binary(), timeout() | search_admin_opts()) ->
+-spec create_search_index(server_ref(), binary(), timeout() | search_admin_opts()) ->
                                  ok | {error, term()}.
 create_search_index(Pid, Index, Timeout)
   when is_integer(Timeout); Timeout =:= infinity ->
@@ -947,7 +949,7 @@ create_search_index(Pid, Index, Timeout)
 create_search_index(Pid, Index, Opts) ->
     create_search_index(Pid, Index, <<>>, Opts).
 
--spec create_search_index(pid(), binary(), binary(),
+-spec create_search_index(server_ref(), binary(), binary(),
                           timeout()|search_admin_opts()) ->
                                  ok | {error, term()}.
 create_search_index(Pid, Index, SchemaName, Timeout)
@@ -977,20 +979,20 @@ create_search_index(Pid, Index, SchemaName, Opts) ->
     call_infinity(Pid, {req, Req1, CT}).
 
 %% @doc Delete a search index.
--spec delete_search_index(pid(), binary()) ->
+-spec delete_search_index(server_ref(), binary()) ->
                     ok | {error, term()}.
 delete_search_index(Pid, Index) ->
     delete_search_index(Pid, Index, []).
 
 %% @doc Delete a search index.
--spec delete_search_index(pid(), binary(), search_admin_opts()) ->
+-spec delete_search_index(server_ref(), binary(), search_admin_opts()) ->
                     ok | {error, term()}.
 delete_search_index(Pid, Index, Opts) ->
     Timeout = proplists:get_value(timeout, Opts, default_timeout(search_timeout)),
     Req = #rpbyokozunaindexdeletereq{name = Index},
     call_infinity(Pid, {req, Req, Timeout}).
 
--spec set_search_index(pid(), bucket() | bucket_and_type(), binary()) ->
+-spec set_search_index(server_ref(), bucket() | bucket_and_type(), binary()) ->
                     ok | {error, term()}.
 set_search_index(Pid, Bucket, Index) ->
     set_bucket(Pid, Bucket, [{search_index, Index}]).
@@ -1002,7 +1004,7 @@ set_search_index(Pid, Bucket, Index) ->
 %%
 %% @deprecated use {@link get_index_eq/4}
 %% @see get_index_eq/4
--spec get_index(pid(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer()) ->
+-spec get_index(server_ref(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer()) ->
                        {ok, index_results()} | {error, term()}.
 get_index(Pid, Bucket, Index, Key) ->
     get_index_eq(Pid, Bucket, Index, Key).
@@ -1012,7 +1014,7 @@ get_index(Pid, Bucket, Index, Key) ->
 %%
 %% @deprecated use {@link get_index_eq/5}
 %% @see get_index_eq/5
--spec get_index(pid(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer(), timeout(), timeout()) ->
+-spec get_index(server_ref(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer(), timeout(), timeout()) ->
                        {ok, index_results()} | {error, term()}.
 get_index(Pid, Bucket, Index, Key, Timeout, _CallTimeout) ->
     get_index_eq(Pid, Bucket, Index, Key, [{timeout, Timeout}]).
@@ -1021,7 +1023,7 @@ get_index(Pid, Bucket, Index, Key, Timeout, _CallTimeout) ->
 %%
 %% @deprecated use {@link get_index_range/5}
 %% @see get_index_range/5
--spec get_index(pid(), bucket(), binary() | secondary_index_id(), key() | integer(), key() | integer()) ->
+-spec get_index(server_ref(), bucket(), binary() | secondary_index_id(), key() | integer(), key() | integer()) ->
                        {ok, index_results()} | {error, term()}.
 get_index(Pid, Bucket, Index, StartKey, EndKey) ->
     get_index_range(Pid, Bucket, Index, StartKey, EndKey).
@@ -1031,7 +1033,7 @@ get_index(Pid, Bucket, Index, StartKey, EndKey) ->
 %%
 %% @deprecated use {@link get_index_range/6}
 %% @see get_index_range/6
--spec get_index(pid(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer() | list(),
+-spec get_index(server_ref(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer() | list(),
                 key() | integer() | list(), timeout(), timeout()) ->
                        {ok, index_results()} | {error, term()}.
 get_index(Pid, Bucket, Index, StartKey, EndKey, Timeout, _CallTimeout) ->
@@ -1040,7 +1042,7 @@ get_index(Pid, Bucket, Index, StartKey, EndKey, Timeout, _CallTimeout) ->
 %% @doc Execute a secondary index equality query.
 %% equivalent to all defaults for the options.
 %% @see get_index_eq/5. for options and their effect
--spec get_index_eq(pid(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer()) ->
+-spec get_index_eq(server_ref(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer()) ->
                        {ok, index_results()} | {error, term()}.
 get_index_eq(Pid, Bucket, Index, Key) ->
     get_index_eq(Pid, Bucket, Index, Key, []).
@@ -1055,7 +1057,7 @@ get_index_eq(Pid, Bucket, Index, Key) ->
 %%                           Expect a <code>continuation</code> in the response if this option is used.</dd>
 %% </dl>
 %% @end
--spec get_index_eq(pid(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer(), index_opts()) ->
+-spec get_index_eq(server_ref(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer(), index_opts()) ->
                        {ok, index_results()} | {error, term()}.
 get_index_eq(Pid, Bucket, {binary_index, Name}, Key, Opts) when is_binary(Key) ->
     Index = list_to_binary(lists:append([Name, "_bin"])),
@@ -1094,7 +1096,7 @@ get_index_eq(Pid, Bucket, Index, Key, Opts) ->
     call_infinity(Pid, Call).
 
 %% @doc Execute a secondary index range query.
--spec get_index_range(pid(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer(), key() | integer()) ->
+-spec get_index_range(server_ref(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer(), key() | integer()) ->
                        {ok, index_results()} | {error, term()}.
 get_index_range(Pid, Bucket, Index, StartKey, EndKey) ->
     get_index_range(Pid, Bucket, Index, StartKey, EndKey, []).
@@ -1106,7 +1108,7 @@ get_index_range(Pid, Bucket, Index, StartKey, EndKey) ->
 %% `{results, [{value, primary_key}]}'
 %% @end
 %% @see get_index_eq/5. for effect of options.
--spec get_index_range(pid(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer() | list(),
+-spec get_index_range(server_ref(), bucket() | bucket_and_type(), binary() | secondary_index_id(), key() | integer() | list(),
                 key() | integer() | list(), range_index_opts()) ->
                        {ok, index_results()} | {error, term()}.
 get_index_range(Pid, Bucket, {binary_index, Name}, StartKey, EndKey, Opts) when is_binary(StartKey) andalso is_binary(EndKey) ->
@@ -1159,7 +1161,7 @@ encode_2i(Value) when is_binary(Value) ->
     Value.
 
 %% @doc secret function, do not use, or I come to your house and keeel you.
--spec cs_bucket_fold(pid(), bucket() | bucket_and_type(), cs_opts()) -> {ok, reference()} | {error, term()}.
+-spec cs_bucket_fold(server_ref(), bucket() | bucket_and_type(), cs_opts()) -> {ok, reference()} | {error, term()}.
 cs_bucket_fold(Pid, Bucket, Opts) when is_pid(Pid), (is_binary(Bucket) orelse
                                                      is_tuple(Bucket)), is_list(Opts) ->
     Timeout = proplists:get_value(timeout, Opts),
@@ -1204,13 +1206,13 @@ default_timeout(OpTimeout) ->
 
 %% @doc Send a pre-encoded msg over the protocol buffer connection
 %% Returns {ok, Response} or {error, Reason}
--spec tunnel(pid(), msg_id(), iolist(), timeout()) -> {ok, binary()} | {error, term()}.
+-spec tunnel(server_ref(), msg_id(), iolist(), timeout()) -> {ok, binary()} | {error, term()}.
 tunnel(Pid, MsgId, Pkt, Timeout) ->
     Req = {tunneled, MsgId, Pkt},
     call_infinity(Pid, {req, Req, Timeout}).
 
 %% @doc increment the pre-Riak 2 counter at `bucket', `key' by `amount'
--spec counter_incr(pid(), bucket() | bucket_and_type(), key(), integer()) -> ok.
+-spec counter_incr(server_ref(), bucket() | bucket_and_type(), key(), integer()) -> ok.
 counter_incr(Pid, Bucket, Key, Amount) ->
     counter_incr(Pid, Bucket, Key, Amount, []).
 
@@ -1218,7 +1220,7 @@ counter_incr(Pid, Bucket, Key, Amount) ->
 %% use the provided `write_quorum()' `Options' for the operation.
 %% A counter increment is a lot like a riak `put' so the semantics
 %% are the same for the given options.
--spec counter_incr(pid(), bucket() | bucket_and_type(), key(), integer(), [write_quorum()]) ->
+-spec counter_incr(server_ref(), bucket() | bucket_and_type(), key(), integer(), [write_quorum()]) ->
     ok | {error, term()}.
 counter_incr(Pid, Bucket, Key, Amount, Options) ->
     {_, B} = maybe_bucket_type(Bucket),
@@ -1226,14 +1228,14 @@ counter_incr(Pid, Bucket, Key, Amount, Options) ->
     call_infinity(Pid, {req, Req, default_timeout(put_timeout)}).
 
 %% @doc get the current value of the pre-Riak 2 counter at `Bucket', `Key'.
--spec counter_val(pid(), bucket() | bucket_and_type(), key()) ->
+-spec counter_val(server_ref(), bucket() | bucket_and_type(), key()) ->
                          {ok, integer()} | {error, notfound}.
 counter_val(Pid, Bucket, Key) ->
     counter_val(Pid, Bucket, Key, []).
 
 %% @doc get the current value of the pre-Riak 2 counter at `Bucket', `Key' using
 %% the `read_qurom()' `Options' provided.
--spec counter_val(pid(), bucket() | bucket_and_type(), key(), [read_quorum()]) ->
+-spec counter_val(server_ref(), bucket() | bucket_and_type(), key(), [read_quorum()]) ->
                          {ok, integer()} | {error, term()}.
 counter_val(Pid, Bucket, Key, Options) ->
     {_, B} = maybe_bucket_type(Bucket),
@@ -1242,7 +1244,7 @@ counter_val(Pid, Bucket, Key, Options) ->
 
 
 %% @doc Fetches the representation of a convergent datatype from Riak.
--spec fetch_type(pid(), bucket_and_type(), Key::binary()) ->
+-spec fetch_type(server_ref(), bucket_and_type(), Key::binary()) ->
                         {ok, riakc_datatype:datatype()} | {error, Reason}
                             when Reason :: {notfound, Type::atom()} | term().
 fetch_type(Pid, BucketAndType, Key) ->
@@ -1250,7 +1252,7 @@ fetch_type(Pid, BucketAndType, Key) ->
 
 %% @doc Fetches the representation of a convergent datatype from Riak,
 %% using the given request options.
--spec fetch_type(pid(), bucket_and_type(), Key::binary(), [proplists:property()]) ->
+-spec fetch_type(server_ref(), bucket_and_type(), Key::binary(), [proplists:property()]) ->
                         {ok, riakc_datatype:datatype()} | {error, Reason}
                             when Reason :: {notfound, Type::atom()} | term().
 fetch_type(Pid, BucketAndType, Key, Options) ->
@@ -1259,7 +1261,7 @@ fetch_type(Pid, BucketAndType, Key, Options) ->
 
 %% @doc Updates the convergent datatype in Riak with local
 %% modifications stored in the container type.
--spec update_type(pid(), bucket_and_type(), Key::binary()|'undefined', Update::riakc_datatype:update(term())) ->
+-spec update_type(server_ref(), bucket_and_type(), Key::binary()|'undefined', Update::riakc_datatype:update(term())) ->
                          ok | {ok, Key::binary()} | {ok, riakc_datatype:datatype()} |
                          {ok, Key::binary(), riakc_datatype:datatype()} | {error, term()}.
 update_type(Pid, BucketAndType, Key, Update) ->
@@ -1268,7 +1270,7 @@ update_type(Pid, BucketAndType, Key, Update) ->
 %% @doc Updates the convergent datatype in Riak with local
 %% modifications stored in the container type, using the given request
 %% options.
--spec update_type(pid(), bucket_and_type(), Key::binary()|'undefined',
+-spec update_type(server_ref(), bucket_and_type(), Key::binary()|'undefined',
                   Update::riakc_datatype:update(term()), [proplists:property()]) ->
                          ok | {ok, Key::binary()} | {ok, riakc_datatype:datatype()} |
                          {ok, Key::binary(), riakc_datatype:datatype()} | {error, term()}.
@@ -1281,7 +1283,7 @@ update_type(Pid, BucketAndType, Key, {Type, Op, Context}, Options) ->
 %% @doc Fetches, applies the given function to the value, and then
 %% updates the datatype in Riak. If an existing value is not found,
 %% but you want the updates to apply anyway, use the 'create' option.
--spec modify_type(pid(), fun((riakc_datatype:datatype()) -> riakc_datatype:datatype()),
+-spec modify_type(server_ref(), fun((riakc_datatype:datatype()) -> riakc_datatype:datatype()),
                   bucket_and_type(), Key::binary(), [proplists:property()]) ->
                          ok | {ok, riakc_datatype:datatype()} | {error, term()}.
 modify_type(Pid, Fun, BucketAndType, Key, ModifyOptions) ->
@@ -1304,14 +1306,14 @@ modify_type(Pid, Fun, BucketAndType, Key, ModifyOptions) ->
 
 %% @doc Get active preflist.
 %% @equiv get_preflist(Pid, Bucket, Key, default_timeout(get_preflist_timeout))
--spec get_preflist(pid(), bucket() | bucket_and_type(), key()) -> {ok, preflist()}
+-spec get_preflist(server_ref(), bucket() | bucket_and_type(), key()) -> {ok, preflist()}
                                                                       | {error, term()}.
 get_preflist(Pid, Bucket, Key) ->
     get_preflist(Pid, Bucket, Key, default_timeout(get_preflist_timeout)).
 
 %% @doc Get active preflist specifying a server side timeout.
 %% @equiv get_preflist(Pid, Bucket, Key, default_timeout(get_preflist_timeout))
--spec get_preflist(pid(), bucket() | bucket_and_type(), key(), timeout()) -> {ok, preflist()}
+-spec get_preflist(server_ref(), bucket() | bucket_and_type(), key(), timeout()) -> {ok, preflist()}
                                                                                  | {error, term()}.
 get_preflist(Pid, Bucket, Key, Timeout) ->
     {T, B} = maybe_bucket_type(Bucket),
@@ -1320,13 +1322,13 @@ get_preflist(Pid, Bucket, Key, Timeout) ->
 
 %% @doc Get minimal coverage plan
 %% @equiv get_coverage(Pid, Bucket, undefined)
--spec get_coverage(pid(), bucket()) -> {ok, term()}
+-spec get_coverage(server_ref(), bucket()) -> {ok, term()}
                                            | {error, term()}.
 get_coverage(Pid, Bucket) ->
     get_coverage(Pid, Bucket, undefined).
 
 %% @doc Get parallel coverage plan if 3rd argument is >= 0
--spec get_coverage(pid(), bucket(), undefined | non_neg_integer()) -> {ok, term()}
+-spec get_coverage(server_ref(), bucket(), undefined | non_neg_integer()) -> {ok, term()}
                                                  | {error, term()}.
 get_coverage(Pid, Bucket, MinPartitions) ->
     Timeout = default_timeout(get_coverage_timeout),


### PR DESCRIPTION
This pull request has three commits.

The first changes the specs for some riak_pb_socket to allow an atom (for a registered name) as an alternative to passing the pid.

The second and third are to get rid of the warnings produced by "make lint". In the second, some values that were declared as string were copied to record fields that were declared to accept only binary; I added a `iolist_to_binary` conversion to silence that warning. In the third, some code is testing for an `undefined` value for record fields that are declared to not allow `undefined`; I diabled dialyzer's no_match warning for that function.