### PR TITLE
Add `node_confirms` option to PUT request

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 ]}.
 
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/nhs-riak/riak_pb.git", {branch, "rdb/2.2.0.0-nhs-2.2.5"}}}
+        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}}
 ]}.
 
 {edoc_opts, [

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 ]}.
 
 {deps, [
-        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "develop-2.2.5"}}}
+        {riak_pb, ".*", {git, "git://github.com/nhs-riak/riak_pb.git", {branch, "develop-2.2"}}}
 ]}.
 
 {edoc_opts, [

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 ]}.
 
 {deps, [
-    {riak_pb, ".*", {git, "https://github.com/basho/riak_pb", {tag, "2.2.0.0"}}}
+        {riak_pb, ".*", {git, "git://github.com/nhs-riak/riak_pb.git", {branch, "rdb/2.2.0.0-nhs-2.2.5"}}}
 ]}.
 
 {edoc_opts, [

--- a/src/riakc_datatype.erl
+++ b/src/riakc_datatype.erl
@@ -112,12 +112,14 @@ module_for_term(T) ->
                    prop_module_for_term]).
 -define(F(Fmt, Args), lists:flatten(io_lib:format(Fmt, Args))).
 datatypes_test_() ->
+    {timeout, 120,
      [{" prop_module_type() ",
        ?_assert(eqc:quickcheck(?QC_OUT(prop_module_type())))}] ++
-     [ {?F(" ~s(~s) ", [Prop, Mod]),
-        ?_assert(eqc:quickcheck(?QC_OUT(eqc:testing_time(2, ?MODULE:Prop(Mod)))))} ||
-         Prop <- ?MODPROPS,
-         Mod <- ?MODULES ].
+         [ {?F(" ~s(~s) ", [Prop, Mod]),
+            ?_assert(eqc:quickcheck(?QC_OUT(eqc:testing_time(2, ?MODULE:Prop(Mod)))))} ||
+             Prop <- ?MODPROPS,
+             Mod <- ?MODULES ]
+    }.
 
 run_props() ->
     run_props(500).

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1582,6 +1582,9 @@ put_options([{n_val, N} | Rest], Req)
 put_options([{sloppy_quorum, Bool} | Rest], Req)
   when Bool == true; Bool == false ->
     put_options(Rest, Req#rpbputreq{sloppy_quorum = Bool});
+put_options([{node_confirms, NodeConfirms} | Rest], Req) ->
+    NCOpt = riak_pb_kv_codec:encode_quorum(NodeConfirms),
+    put_options(Rest, Req#rpbputreq{node_confirms = NCOpt});
 put_options([{_, _} | _Rest], _Req) ->
     erlang:error(badarg).
 
@@ -1642,6 +1645,8 @@ counter_incr_options([{dw, DW} | Rest], Req) ->
     counter_incr_options(Rest, Req#rpbcounterupdatereq{dw=riak_pb_kv_codec:encode_quorum(DW)});
 counter_incr_options([{pw, PW} | Rest], Req) ->
     counter_incr_options(Rest, Req#rpbcounterupdatereq{pw=riak_pb_kv_codec:encode_quorum(PW)});
+counter_incr_options([{node_confirms, NodeConfirms} | Rest], Req) ->
+    counter_incr_options(Rest, Req#rpbcounterupdatereq{node_confirms=riak_pb_kv_codec:encode_quorum(NodeConfirms)});
 counter_incr_options([returnvalue | Rest], Req) ->
     counter_incr_options(Rest, Req#rpbcounterupdatereq{returnvalue=true});
 counter_incr_options([_ | _Rest], _Req) ->


### PR DESCRIPTION
And counter/datatype operations. NOTE: depends on riak-2.2.5
node_confirms feature.

Depends on:
https://github.com/basho/riak_pb/pull/228

Depended on:
https://github.com/basho/riak_kv/pull/1663