### PR TITLE
Add support for Erlang/OTP 21

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R15|R16|17|18|19|20"}.
+{require_otp_vsn, "R15|R16|17|18|19|20|21"}.
 
 {cover_enabled, true}.
 
@@ -10,7 +10,8 @@
     {platform_define, "^[0-9]+", namespaced_types},
     {platform_define, "(?=^[0-9]+)(?!^17)", deprecated_now},
     {platform_define, "^19", deprecated_19},
-    {platform_define, "^20", deprecated_19}
+    {platform_define, "^20", deprecated_19},
+    {platform_define, "^21", deprecated_19},
 ]}.
 
 {deps, [

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
     {platform_define, "(?=^[0-9]+)(?!^17)", deprecated_now},
     {platform_define, "^19", deprecated_19},
     {platform_define, "^20", deprecated_19},
-    {platform_define, "^21", deprecated_19},
+    {platform_define, "^21", deprecated_19}
 ]}.
 
 {deps, [

--- a/src/riakc.app.src
+++ b/src/riakc.app.src
@@ -14,6 +14,7 @@
          %% e.g. get_timeout, put_timeout that will 
          %% override the default.
          {timeout, 60000}
-        ]}
+        ]},
+  {modules, []}
  ]}.
 


### PR DESCRIPTION
Hello,

I added the ``deprecation_19`` define for OTP 21 (see #365 for more informations).