### PR TITLE
change keepalive setting to mean true when specified in Options

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -1493,7 +1493,7 @@ parse_options([auto_reconnect|Options], State) ->
 parse_options([{keepalive,Bool}|Options], State) when is_boolean(Bool) ->
     parse_options(Options, State#state{keepalive = Bool});
 parse_options([keepalive|Options], State) ->
-    parse_options([{keepalive, false}|Options], State);
+    parse_options([{keepalive, true}|Options], State);
 parse_options([{credentials, User, Pass}|Options], State) ->
     parse_options(Options, State#state{credentials={User, Pass}});
 parse_options([{certfile, File}|Options], State) ->


### PR DESCRIPTION
An Erlang developer expects the atoms in options to denote the `true`
boolean value. So, when `keepalive` is in the options we expect that
keepalive feature is turned on.

In theory this is a backward incompatible change but in practice I cannot
imagine anyone setting `[keepalive, ...]` and expecting `[{keepalive, false},
...]` which is the default anyway.