### PR TITLE
compiling for erlang 22 and tests passing deprecated_19 for all future versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R15|R16|17|18|19|20|21"}.
+{require_otp_vsn, "R15|R16|17|18|19|20|21|22"}.
 
 {cover_enabled, true}.
 
@@ -10,8 +10,7 @@
     {platform_define, "^[0-9]+", namespaced_types},
     {platform_define, "(?=^[0-9]+)(?!^17)", deprecated_now},
     {platform_define, "^19", deprecated_19},
-    {platform_define, "^20", deprecated_19},
-    {platform_define, "^21", deprecated_19}
+    {platform_define, "^[2-9][0-9]+(.?[0-9]*)", deprecated_19}
 ]}.
 
 {deps, [


### PR DESCRIPTION
Hopefully the regex is okay. I was trying to compile riak 3.0 on erlang 22 and this caused issues.