### PR TITLE
Reconnect issue

### DIFF
--- a/include/riakc.hrl
+++ b/include/riakc.hrl
@@ -190,7 +190,7 @@
         {fl, [binary()]} |           %% Return fields limit (for ids only, generally)
         {presort, binary()}.         %% Presor (key / score)
 
--type search_doc() :: [{binary(), binary()}].
+-type search_doc() :: {binary(), [{binary(), binary()}]}.
 -type search_maxscore() :: float().
 -type search_number_found() :: non_neg_integer().
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+[{<<"hamcrest">>,
+  {git,"https://github.com/basho/hamcrest-erlang.git",
+       {ref,"ad3dbab419762fc2d5821abb88b989da006b85c6"}},
+  1},
+ {<<"riak_pb">>,
+  {git,"https://github.com/basho/riak_pb",
+       {ref,"08771aba2ce4935b715d32d1b92555efdc3da994"}},
+  0}].

--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -295,7 +295,11 @@ get_server_info(Pid, Timeout) ->
 %% @doc Get bucket/key from the server.
 %%      Will return {error, notfound} if the key is not on the server.
 %% @equiv get(Pid, Bucket, Key, [], default_timeout(get_timeout))
--spec get(pid(), bucket() | bucket_and_type(), key()) -> {ok, riakc_obj()} | {error, term()}.
+-spec get(pid(), bucket() | bucket_and_type(), key()) ->
+    {ok, riakc_obj()}
+    | {error, term()}
+    | {error, notfound, riakc_obj:vclock()}
+    | unchanged.
 get(Pid, Bucket, Key) ->
     get(Pid, Bucket, Key, [], default_timeout(get_timeout)).
 
@@ -303,7 +307,7 @@ get(Pid, Bucket, Key) ->
 %%      Will return {error, notfound} if the key is not on the server.
 %% @equiv get(Pid, Bucket, Key, Options, Timeout)
 -spec get(pid(), bucket() | bucket_and_type(), key(), TimeoutOrOptions::timeout() |  get_options()) ->
-                 {ok, riakc_obj()} | {error, term()} | unchanged.
+                 {ok, riakc_obj()} | {error, term()} | {error, notfound, riakc_obj:vclock()} | unchanged.
 get(Pid, Bucket, Key, Timeout) when is_integer(Timeout); Timeout =:= infinity ->
     get(Pid, Bucket, Key, [], Timeout);
 get(Pid, Bucket, Key, Options) ->
@@ -314,7 +318,7 @@ get(Pid, Bucket, Key, Options) ->
 %%      <code>{if_modified, Vclock}</code> option is specified and the
 %%      object is unchanged.
 -spec get(pid(), bucket() | bucket_and_type(), key(), get_options(), timeout()) ->
-                 {ok, riakc_obj()} | {error, term()} | unchanged.
+                 {ok, riakc_obj()} | {error, term()} | {error, notfound, riakc_obj:vclock()}  | unchanged.
 get(Pid, Bucket, Key, Options, Timeout) ->
     {T, B} = maybe_bucket_type(Bucket),
     Req = get_options(Options, #rpbgetreq{type =T, bucket = B, key = Key}),


### PR DESCRIPTION
In case of tls connection when reconnect option is enabled, any connection error will cause of creation of a new socket connection and didn't dispose failed connection
Fix some dialyzer issues