### PR TITLE
Extend 'continuation' value type to undefined | binary()

### DIFF
--- a/src/riakc_pb_socket.erl
+++ b/src/riakc_pb_socket.erl
@@ -122,7 +122,7 @@
 -type index_opt() :: {timeout, timeout()} |
                      {call_timeout, timeout()} |
                      {stream, boolean()} |
-                     {continuation, binary()} |
+                     {continuation, continuation()} |
                      {pagination_sort, boolean()} |
                      {max_results, non_neg_integer() | all}.
 -type index_opts() :: [index_opt()].


### PR DESCRIPTION
This is to bring the `index_options()` type in agreement with actual usage, as seen for example in riak_cs: [here](https://github.com/TI-Tokyo/riak_cs/blob/develop/apps/riak_cs/src/riak_cs_gc_key_list.erl#L126) its `continuation` option is explicitly [set](https://github.com/TI-Tokyo/riak_cs/blob/develop/apps/riak_cs/src/riak_cs_gc_key_list.erl#L160) to `undefined`.

Spotted by dialyzer.